### PR TITLE
docs: App Store Connect setup, TestFlight CLI fix, updated resources

### DIFF
--- a/docs/cloudflare-resources.md
+++ b/docs/cloudflare-resources.md
@@ -31,6 +31,14 @@
 | POST | `/api/inbox/:card_id/respond` | User responds |
 | POST | `/api/opus/analyze` | Trigger Opus analysis |
 
+## App Store Connect
+- **App Name:** ROBO.APP
+- **App ID:** `6759011077`
+- **Bundle ID:** `com.silv.Robo`
+- **SKU:** `robo`
+- **Apple ID:** `matt@argentlabs.xyz`
+- **Dashboard:** https://appstoreconnect.apple.com/apps/6759011077/distribution/ios/version/inflight
+
 ## Wrangler Commands
 
 ```bash

--- a/docs/solutions/build-errors/app-store-connect-new-app-setup-20260210.md
+++ b/docs/solutions/build-errors/app-store-connect-new-app-setup-20260210.md
@@ -1,0 +1,64 @@
+---
+title: "App Store Connect: New App Setup for TestFlight"
+category: build-errors
+date: 2026-02-10
+tags: [app-store-connect, testflight, bundle-id, apple-developer]
+component: ios-deployment
+severity: blocking
+resolution_time: 15min
+---
+
+# App Store Connect: New App Setup for TestFlight
+
+**Problem:** Cannot create a new app in App Store Connect because the Bundle ID dropdown is empty — the Bundle ID must be registered separately in the Apple Developer portal first.
+
+**Symptoms:**
+- App Store Connect → My Apps → New App shows "Choose" in Bundle ID dropdown
+- No option to type a custom Bundle ID
+
+**Solution — Step by Step:**
+
+## 1. Register Bundle ID (Apple Developer Portal)
+Go to https://developer.apple.com/account/resources/identifiers/add/bundleId
+
+- Platform: iOS, iPadOS, macOS, tvOS, watchOS, visionOS (default)
+- Description: `Robo`
+- Bundle ID: Explicit → `com.silv.Robo`
+- Capabilities: Leave defaults (Camera access is via Info.plist, not App ID capabilities)
+- Click Continue → Register
+
+## 2. Create App Record (App Store Connect)
+Go to https://appstoreconnect.apple.com → My Apps → "+"
+
+- Platform: iOS
+- Name: Must be unique on App Store (we used "ROBO.APP" since "Robo" was taken)
+- Primary Language: English (U.S.)
+- Bundle ID: Select `com.silv.Robo` from dropdown (now appears after step 1)
+- SKU: `robo` (internal identifier, never shown to users)
+- User Access: Full Access
+
+## 3. Generate App-Specific Password (for CLI uploads)
+Go to https://account.apple.com → Sign-In and Security → App-Specific Passwords → "+"
+
+- Name it descriptively (e.g., "robo-upload")
+- Save the password securely (shown once)
+
+## Key Details for Robo
+- **App Name:** ROBO.APP
+- **App ID:** 6759011077
+- **Bundle ID:** com.silv.Robo
+- **SKU:** robo
+- **Apple ID:** matt@argentlabs.xyz
+- **Team:** OtoCo DE LLC (R3Z5CY34Q5)
+- **Dashboard:** https://appstoreconnect.apple.com/apps/6759011077/distribution/ios/version/inflight
+
+## Common Gotchas
+- Bundle ID registration is in the **Apple Developer portal** (developer.apple.com), NOT App Store Connect (appstoreconnect.apple.com) — they're separate sites
+- Camera/sensor permissions are configured via Info.plist, not App ID capabilities
+- App name must be globally unique on the App Store
+- SKU is just an internal identifier — use something simple like the app name
+
+## Related Resources
+- [Apple Developer Portal](https://developer.apple.com/account/)
+- [App Store Connect](https://appstoreconnect.apple.com/)
+- [TestFlight Documentation](https://developer.apple.com/testflight/)

--- a/docs/solutions/build-errors/testflight-cli-export-copy-failed-20260210.md
+++ b/docs/solutions/build-errors/testflight-cli-export-copy-failed-20260210.md
@@ -1,0 +1,85 @@
+---
+title: "TestFlight CLI Export: Copy Failed at IPA Creation"
+category: build-errors
+date: 2026-02-10
+tags: [testflight, xcodebuild, codesign, distribution-certificate, cli]
+component: ios-build
+severity: blocking
+resolution_time: 20min
+---
+
+# TestFlight CLI Export: Copy Failed at IPA Creation
+
+## Problem
+
+`xcodebuild -exportArchive` fails with "Copy failed" at the `IDEDistributionCreateIPAStep` when trying to export an archive for App Store Connect / TestFlight upload via CLI.
+
+## Symptoms
+
+- `error: exportArchive Copy failed` with no other useful error message
+- Distribution logs show `IDEDistributionPackagingStep` or `IDEDistributionCreateIPAStep` failing
+- Codesign step succeeds (app is signed) but IPA creation fails
+- The `ExportOptions.plist` method `app-store` is deprecated (should be `app-store-connect`)
+
+## Root Cause
+
+No Apple Distribution certificate installed in the local keychain. Only Apple Development certificates were present. The CLI export process attempts cloud signing but fails silently at the IPA packaging step. The error message "Copy failed" is misleading — it's actually a signing/packaging issue.
+
+## Investigation Steps
+
+1. Checked distribution logs at `/var/folders/.../Robo_*.xcdistributionlogs/`
+2. Found `IDEDistributionCreateIPAStep` failing after successful codesign
+3. Ran `security find-identity -v -p codesigning` — only Development certs, no Distribution cert
+4. The verbose log showed Xcode found "Apple Distribution: OtoCo DE LLC" via cloud signing but the local packaging step still failed
+
+## Solution
+
+Use Xcode Organizer GUI instead of CLI for TestFlight uploads when no local Distribution certificate is installed:
+
+```bash
+# Build the archive via CLI (this works fine with Development cert)
+cd ios
+xcodebuild archive \
+  -scheme Robo -configuration Release \
+  -archivePath ./build/Robo.xcarchive \
+  -destination 'generic/platform=iOS' \
+  -allowProvisioningUpdates \
+  DEVELOPMENT_TEAM=R3Z5CY34Q5
+
+# Open in Xcode Organizer (handles cloud signing automatically)
+open ./build/Robo.xcarchive
+
+# Then: Distribute App → TestFlight Internal Testing → Distribute
+```
+
+## Alternative Fix (For Full CLI Automation)
+
+Install an Apple Distribution certificate locally:
+
+1. Go to https://developer.apple.com/account/resources/certificates/add
+2. Create "Apple Distribution" certificate
+3. Download and double-click to install in Keychain
+4. Then `xcodebuild -exportArchive` will work via CLI
+
+## Also Fix: Update ExportOptions.plist
+
+The `app-store` method is deprecated, use `app-store-connect`:
+
+```xml
+<key>method</key>
+<string>app-store-connect</string>
+```
+
+And remove `uploadBitcode` key (deprecated in Xcode 16+).
+
+## Prevention
+
+- Always verify `security find-identity -v -p codesigning` includes a Distribution cert before attempting CLI export
+- Use Xcode Organizer as fallback — it handles cloud signing seamlessly
+- Keep ExportOptions.plist up to date with current Xcode conventions
+
+## Related Issues
+
+- This is common when working on a new machine or after a fresh macOS install
+- Cloud signing works great in Xcode GUI but has limitations with CLI workflows
+- The misleading "Copy failed" error masks the real signing/certificate issue

--- a/ios/ExportOptions.plist
+++ b/ios/ExportOptions.plist
@@ -3,16 +3,16 @@
 <plist version="1.0">
 <dict>
     <key>method</key>
-    <string>app-store</string>
+    <string>app-store-connect</string>
     <key>teamID</key>
     <string>R3Z5CY34Q5</string>
-    <key>uploadBitcode</key>
-    <false/>
     <key>uploadSymbols</key>
     <true/>
     <key>signingStyle</key>
     <string>automatic</string>
     <key>destination</key>
     <string>upload</string>
+    <key>testFlightInternalTestingOnly</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- Added solution doc for `xcodebuild -exportArchive` "Copy failed" error (missing Distribution cert workaround)
- Added solution doc for App Store Connect new app setup flow (Bundle ID in Developer portal, not ASC)
- Updated `cloudflare-resources.md` with App Store Connect details (app ID, Apple ID, dashboard link)
- Fixed `ExportOptions.plist`: deprecated `app-store` → `app-store-connect`, removed `uploadBitcode`

## Test plan
- [ ] Docs render correctly in GitHub
- [ ] ExportOptions.plist changes validated against Xcode 16+ requirements

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>