### PR TITLE
fix: floor area, history export, encryption compliance

### DIFF
--- a/docs/solutions/build-errors/homebrew-rsync-xcode-export-archive-fix-20260210.md
+++ b/docs/solutions/build-errors/homebrew-rsync-xcode-export-archive-fix-20260210.md
@@ -1,0 +1,139 @@
+---
+title: "Homebrew rsync breaks Xcode exportArchive for TestFlight"
+category: build-errors
+date: 2026-02-10
+component: ios-build
+tags: [xcode, rsync, homebrew, testflight, export-archive, cli]
+severity: critical
+symptoms: ["exportArchive Copy failed", "rsync error syntax or usage error", "--extended-attributes unknown option"]
+---
+
+# Homebrew rsync breaks Xcode exportArchive for TestFlight
+
+## Problem
+
+`xcodebuild -exportArchive` fails with a "Copy failed" error when trying to export an archive for App Store Connect / TestFlight upload. The archive step succeeds fine — only the export step fails.
+
+## Symptoms
+
+- `xcodebuild -exportArchive` outputs:
+  ```
+  error: exportArchive Copy failed
+  ** EXPORT FAILED **
+  ```
+- Distribution log shows:
+  ```
+  rsync error: syntax or usage error (code 1) at main.c(1802) [server=3.4.1]
+  rsync: on remote machine: --extended-attributes: unknown option
+  ```
+- The archive step (`xcodebuild archive`) completes successfully with no issues.
+- Only the export/upload step fails.
+
+## Root Cause
+
+Homebrew's rsync (version 3.4.1, installed at `/opt/homebrew/bin/rsync`) conflicts with Apple's openrsync (`/usr/bin/rsync`).
+
+Here is what happens during IPA creation:
+
+1. Xcode uses `/usr/bin/rsync` (Apple's openrsync) as the **client** side of the rsync transfer.
+2. The client passes `--extended-attributes`, which is an Apple-specific flag supported by openrsync.
+3. When rsync launches the **server** side of the transfer, it searches `PATH` for the `rsync` binary.
+4. If Homebrew's rsync comes first in `PATH` (which it does by default on Apple Silicon Macs with Homebrew), the server side runs Homebrew rsync 3.4.1.
+5. Homebrew rsync 3.4.1 does **not** understand the `--extended-attributes` flag, so it exits with a syntax/usage error.
+6. The copy fails and `xcodebuild -exportArchive` reports `EXPORT FAILED`.
+
+The mismatch between Apple's openrsync (client) and Homebrew's rsync (server) is the core issue.
+
+## Solution
+
+Strip Homebrew from `PATH` when running the export command so that both client and server use Apple's `/usr/bin/rsync`:
+
+```bash
+PATH="/usr/bin:/bin:/usr/sbin:/sbin" xcodebuild -exportArchive \
+  -archivePath /tmp/Robo.xcarchive \
+  -exportPath /tmp/RoboExport \
+  -exportOptionsPlist /tmp/ExportOptions.plist \
+  -allowProvisioningUpdates
+```
+
+This ensures `/usr/bin/rsync` (openrsync) is used for both sides of the transfer, and `--extended-attributes` is understood correctly.
+
+## Full TestFlight CLI Workflow
+
+Complete end-to-end workflow to build, archive, export, and upload to TestFlight from the command line with no Xcode UI:
+
+```bash
+# 1. Bump CURRENT_PROJECT_VERSION in project.yml
+# 2. Regenerate the Xcode project
+cd ios && xcodegen generate
+
+# 3. Archive
+xcodebuild archive -scheme Robo -archivePath /tmp/Robo.xcarchive \
+  -destination 'generic/platform=iOS' -allowProvisioningUpdates \
+  DEVELOPMENT_TEAM=R3Z5CY34Q5
+
+# 4. Export + upload (MUST strip Homebrew from PATH)
+PATH="/usr/bin:/bin:/usr/sbin:/sbin" xcodebuild -exportArchive \
+  -archivePath /tmp/Robo.xcarchive -exportPath /tmp/RoboExport \
+  -exportOptionsPlist /tmp/ExportOptions.plist -allowProvisioningUpdates
+```
+
+## ExportOptions.plist
+
+Save this as `/tmp/ExportOptions.plist` (or wherever you prefer):
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>method</key>
+  <string>app-store-connect</string>
+  <key>teamID</key>
+  <string>R3Z5CY34Q5</string>
+  <key>signingStyle</key>
+  <string>automatic</string>
+  <key>destination</key>
+  <string>upload</string>
+</dict>
+</plist>
+```
+
+Key points about ExportOptions.plist:
+- Use `app-store-connect` (not `app-store`) as the method.
+- Do **not** include `uploadBitcode` — it is deprecated and will cause errors.
+- `destination: upload` tells Xcode to upload directly to App Store Connect after export.
+
+## Prevention
+
+- **Always** use `PATH="/usr/bin:/bin:/usr/sbin:/sbin"` as a prefix on `xcodebuild -exportArchive` commands.
+- Alternatively, uninstall Homebrew rsync if you do not need it: `brew uninstall rsync`.
+- Check which rsync is active: `which rsync`. If it shows `/opt/homebrew/bin/rsync`, you will hit this issue.
+
+## How to Find the Error
+
+When `xcodebuild -exportArchive` fails, it prints a path to the distribution logs in its output. Look for something like:
+
+```
+/var/folders/.../IDEDistribution/
+```
+
+Inside that directory, check `IDEDistributionPipeline.log` and grep for "rsync":
+
+```bash
+grep rsync /var/folders/.../IDEDistribution/IDEDistributionPipeline.log
+```
+
+This will surface the actual rsync error message showing the version mismatch and the `--extended-attributes: unknown option` failure.
+
+## Environment
+
+- macOS 15 (Sequoia) on Apple Silicon
+- Xcode 16+
+- Homebrew rsync 3.4.1 at `/opt/homebrew/bin/rsync`
+- Apple openrsync at `/usr/bin/rsync`
+
+## Related
+
+- [TestFlight CLI Export Copy Failed](testflight-cli-export-copy-failed-20260210.md) — earlier troubleshooting of the same symptom before root cause was identified
+- [App Store Connect New App Setup](app-store-connect-new-app-setup-20260210.md) — setting up the app in ASC for the first time

--- a/docs/solutions/logic-errors/roomplan-floor-area-zero-sqft-fix-20260210.md
+++ b/docs/solutions/logic-errors/roomplan-floor-area-zero-sqft-fix-20260210.md
@@ -1,0 +1,137 @@
+---
+title: "RoomPlan floor area returns 0.0 sq ft — shoelace formula on unordered wall positions"
+category: logic-errors
+date: 2026-02-10
+component: ios-lidar
+tags: [roomplan, lidar, floor-area, shoelace-formula, capturedroom, ios17]
+severity: high
+symptoms: ["0.0 sq ft", "floor area zero", "area calculation wrong"]
+---
+
+# RoomPlan Floor Area Returns 0.0 sq ft — Shoelace Formula on Unordered Wall Positions
+
+## Problem
+
+After completing a LiDAR room scan, the scan results screen displays "0.0 sq ft (0.0 m2)" for floor area even though walls, doors, windows, and objects are all detected correctly.
+
+## Symptoms
+
+- Floor area displays as "0.0 sq ft" on the scan results screen
+- Wall count, door count, window count, and object count are all correct
+- Ceiling height may also show 0 if it was derived from the floor area calculation
+- The bug only manifests with real LiDAR scans, not mock/test data
+
+## Root Cause
+
+The original `estimateFloorArea()` function used the shoelace formula on wall center positions (`transform.columns.3`), treating them as ordered polygon vertices. This is fundamentally wrong because RoomPlan wall surfaces are NOT ordered as a polygon -- they are individual surfaces floating in 3D space with no guaranteed ordering.
+
+The shoelace formula requires vertices to be ordered sequentially around a polygon perimeter. When applied to unordered wall center points, the formula produces near-zero or wildly incorrect areas because the "polygon" it traces crosses over itself repeatedly, with positive and negative area contributions canceling out.
+
+### Why it produces exactly 0.0
+
+With unordered points, the shoelace formula traces a self-intersecting path. The positive and negative area contributions from the crossing edges nearly cancel out, resulting in a value very close to zero. After `abs()` and rounding for display, this shows as "0.0 sq ft".
+
+## Original Broken Code
+
+In `RoomDataProcessor.swift`:
+
+```swift
+static func estimateFloorArea(_ walls: [CapturedRoom.Surface]) -> Double {
+    guard walls.count >= 4 else {
+        let perimeter = walls.reduce(0.0) { $0 + Double($1.dimensions.x) }
+        let side = perimeter / 4.0
+        return side * side
+    }
+    let points = walls.map { wall -> (Double, Double) in
+        let col3 = wall.transform.columns.3  // Wall CENTER position
+        return (Double(col3.x), Double(col3.z))
+    }
+    // Shoelace formula on UNORDERED points = wrong!
+    var area = 0.0
+    for i in 0..<points.count {
+        let j = (i + 1) % points.count
+        area += points[i].0 * points[j].1
+        area -= points[j].0 * points[i].1
+    }
+    return abs(area) / 2.0
+}
+```
+
+The critical flaw: `walls.map { ... }` iterates walls in whatever order RoomPlan returns them, which is NOT a polygon traversal order. The shoelace formula then connects these arbitrary points in sequence, forming a self-intersecting shape with near-zero net area.
+
+## Fixed Code
+
+Three-tier approach per Apple RoomPlan documentation:
+
+```swift
+static func estimateFloorArea(_ room: CapturedRoom) -> Double {
+    // Best: use actual floor surfaces (iOS 17+)
+    if !room.floors.isEmpty {
+        return room.floors.reduce(0.0) { total, floor in
+            let corners = floor.polygonCorners
+            if corners.count >= 3 {
+                return total + polygonArea(corners)
+            }
+            return total + Double(floor.dimensions.x) * Double(floor.dimensions.z)
+        }
+    }
+    // Fallback: bounding box from wall positions
+    if let dims = estimateRoomDimensions(room.walls) {
+        return dims.length * dims.width
+    }
+    // Last resort: assume square from perimeter
+    let perimeter = room.walls.reduce(0.0) { $0 + Double($1.dimensions.x) }
+    let side = perimeter / 4.0
+    return side * side
+}
+
+private static func polygonArea(_ corners: [simd_float3]) -> Double {
+    var area = 0.0
+    for i in 0..<corners.count {
+        let j = (i + 1) % corners.count
+        area += Double(corners[i].x) * Double(corners[j].z)
+        area -= Double(corners[j].x) * Double(corners[i].z)
+    }
+    return abs(area) / 2.0
+}
+```
+
+### Why this works
+
+1. **Tier 1 -- `room.floors`**: RoomPlan on iOS 17+ detects floor surfaces directly. `Surface.polygonCorners` returns the actual polygon vertices of the floor in local plane coordinates, already ordered correctly. The shoelace formula works correctly on these ordered vertices.
+
+2. **Tier 2 -- Bounding box**: If no floor surfaces are detected, compute the axis-aligned bounding box from wall positions. This gives a rectangular approximation (length x width) which is reasonable for most rooms.
+
+3. **Tier 3 -- Square from perimeter**: Last resort fallback. Sum all wall widths to get the perimeter, assume a square room, and compute area. This is the least accurate but always produces a non-zero result.
+
+### Key signature change
+
+The function signature changed from taking `[CapturedRoom.Surface]` (just walls) to taking `CapturedRoom` (the full room). This is necessary to access `room.floors`, which is the primary data source for floor area.
+
+## Key RoomPlan API Insights
+
+From Apple documentation:
+
+- **`CapturedRoom.floors`** (iOS 17+): Array of floor surfaces detected by RoomPlan. This is the best and most direct source for floor area calculation.
+
+- **`Surface.polygonCorners`** (iOS 17+): Returns the actual polygon vertices of a surface in local plane coordinates. These vertices ARE ordered correctly for the shoelace formula, unlike wall center positions.
+
+- **`Surface.dimensions`**: The bounding box of the surface as a `simd_float3` (width x height x depth). Useful as a fallback when `polygonCorners` is unavailable or has fewer than 3 points.
+
+- **`Surface.transform.columns.3`**: The surface's position in world space. Useful for computing bounding boxes and relative positions, but NOT suitable as polygon vertices for area calculation.
+
+- **Wall ordering**: RoomPlan does not guarantee any particular ordering of walls in the `CapturedRoom.walls` array. Walls may be returned in detection order, spatial clustering order, or any other internal ordering. Never assume they form a polygon perimeter.
+
+## Prevention
+
+- **Always prefer `CapturedRoom.floors`** over computing area from walls. Apple provides floor detection specifically for this purpose.
+
+- **When using the shoelace formula**, ensure the input points are ordered polygon vertices (like `polygonCorners`), not arbitrary positions extracted from unrelated surfaces.
+
+- **Test with real LiDAR scans, not just mock data.** The 0.0 bug only appears with real RoomPlan data because mock data often uses conveniently ordered wall positions that happen to produce correct results.
+
+- **Validate area results against expected ranges.** A room with 4+ detected walls should never have a floor area of 0.0. Add a sanity check or log a warning when the computed area is suspiciously low relative to the detected wall count.
+
+## Files
+
+- `ios/Robo/Services/RoomDataProcessor.swift` -- `estimateFloorArea()` and `polygonArea()` functions

--- a/ios/Robo/Views/RoomResultView.swift
+++ b/ios/Robo/Views/RoomResultView.swift
@@ -12,7 +12,7 @@ struct RoomResultView: View {
     @State private var exportError: String?
 
     private var floorArea: Double {
-        RoomDataProcessor.estimateFloorArea(room.walls)
+        RoomDataProcessor.estimateFloorArea(room)
     }
 
     private var floorAreaSqFt: Double {

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -12,7 +12,7 @@ settings:
     CODE_SIGN_STYLE: Automatic
     PRODUCT_NAME: Robo
     MARKETING_VERSION: 1.0
-    CURRENT_PROJECT_VERSION: 2
+    CURRENT_PROJECT_VERSION: 5
     SWIFT_VERSION: 5.9
     IPHONEOS_DEPLOYMENT_TARGET: 17.0
     TARGETED_DEVICE_FAMILY: 1  # iPhone only
@@ -54,5 +54,6 @@ targets:
         UIRequiresFullScreen: true
         UISupportedInterfaceOrientations:
           - UIInterfaceOrientationPortrait
+        ITSAppUsesNonExemptEncryption: false
         NSCameraUsageDescription: "Robo needs camera access to scan barcodes, capture photos, and perform LiDAR room scanning for AI analysis"
         NSPhotoLibraryUsageDescription: "Robo needs photo library access to save captured images"


### PR DESCRIPTION
## Summary

- **Fix 0.0 sq ft bug**: Floor area calculation was using shoelace formula on unordered wall positions (always near-zero). Now uses `CapturedRoom.floors` with `polygonCorners` (iOS 17+) for accurate area, with bounding box and perimeter fallbacks.
- **History export**: Swipe left/right on room scan rows to share as ZIP (room_summary.json + room_full.json) via standard iOS share sheet.
- **Encryption compliance**: Moved `ITSAppUsesNonExemptEncryption` from Info.plist into `project.yml` so `xcodegen generate` preserves it (was being dropped on regeneration, causing "Missing Compliance" in TestFlight).
- **Solution docs**: Documented Homebrew rsync/Xcode export fix and RoomPlan floor area calculation.

## Test plan

- [ ] LiDAR scan a room → verify floor area shows realistic sq ft (not 0.0)
- [ ] Save scan to history → swipe left on row → tap Share → verify ZIP export
- [ ] TestFlight build 1.0(5) should show "Testing" (not "Missing Compliance")
- [ ] Run `xcodegen generate` → verify Info.plist still has `ITSAppUsesNonExemptEncryption`

🤖 Generated with [Claude Code](https://claude.com/claude-code)