### PR TITLE
fix: SwiftData persistence reliability and concurrency safety

### DIFF
--- a/ios/Robo/Views/BarcodeScannerView.swift
+++ b/ios/Robo/Views/BarcodeScannerView.swift
@@ -107,7 +107,11 @@ struct BarcodeScannerView: View {
         // Save to SwiftData (explicit save — autosave is unreliable during dismiss)
         let record = ScanRecord(barcodeValue: code, symbology: symbology)
         modelContext.insert(record)
-        try? modelContext.save()
+        do {
+            try modelContext.save()
+        } catch {
+            self.error = "Failed to save scan: \(error.localizedDescription)"
+        }
 
         // Show toast (replaces previous)
         currentToast = ToastItem(code: code, symbology: symbology)

--- a/ios/Robo/Views/ScanHistoryView.swift
+++ b/ios/Robo/Views/ScanHistoryView.swift
@@ -129,6 +129,7 @@ struct ScanHistoryView: View {
 
                             Button(role: .destructive) {
                                 modelContext.delete(room)
+                                try? modelContext.save()
                             } label: {
                                 Label("Delete", systemImage: "trash")
                             }
@@ -161,12 +162,14 @@ struct ScanHistoryView: View {
         for index in offsets {
             modelContext.delete(scans[index])
         }
+        try? modelContext.save()
     }
 
     private func deleteRoomScans(at offsets: IndexSet) {
         for index in offsets {
             modelContext.delete(roomScans[index])
         }
+        try? modelContext.save()
     }
 
     private func clearAll() {
@@ -179,16 +182,21 @@ struct ScanHistoryView: View {
                 modelContext.delete(room)
             }
         }
+        try? modelContext.save()
     }
 
     private func exportRoom(_ room: RoomScanRecord) {
         exportingRoomID = room.persistentModelID
+        // Extract SwiftData model properties before crossing isolation boundary
+        let name = room.roomName
+        let summary = room.summaryJSON
+        let fullData = room.fullRoomDataJSON
         Task.detached {
             do {
                 let url = try ExportService.createRoomExportZipFromData(
-                    roomName: room.roomName,
-                    summaryJSON: room.summaryJSON,
-                    fullRoomDataJSON: room.fullRoomDataJSON
+                    roomName: name,
+                    summaryJSON: summary,
+                    fullRoomDataJSON: fullData
                 )
                 await MainActor.run {
                     shareURL = url


### PR DESCRIPTION
## Summary
- **#37**: Enforce deterministic SwiftData saves — save errors surfaced in barcode flow, explicit `modelContext.save()` after all delete operations (swipe, bulk clear)
- **#38**: Fix unsafe `Task.detached` access — extract SwiftData `@Model` properties to local variables before crossing isolation boundaries; encode `CapturedRoom` data on main actor before detached task

## Files Changed
- `BarcodeScannerView.swift` — `try?` → `do/catch` with user-visible error
- `ScanHistoryView.swift` — explicit saves after deletes, extract model props before `Task.detached`
- `RoomResultView.swift` — encode room data before isolation boundary, reuse `createRoomExportZipFromData`

## Test Plan
- [ ] Scan barcode → verify save error alert appears on failure
- [ ] Swipe-delete barcode/room → verify deletion persists after app restart
- [ ] Clear All → verify all records gone after app restart
- [ ] Export room from history → verify ZIP created correctly
- [ ] Export room from result view → verify ZIP created correctly

Closes #37, closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)