### PR TITLE
feat: floor area fix, detail views, bulk export, tests, debug sync

### DIFF
--- a/ios/Robo/Services/DebugSyncService.swift
+++ b/ios/Robo/Services/DebugSyncService.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+#if DEBUG
+enum DebugSyncService {
+    static var isEnabled: Bool {
+        UserDefaults.standard.bool(forKey: "dev.syncToCloud")
+    }
+
+    private static var deviceConfig: DeviceConfig {
+        if let data = UserDefaults.standard.data(forKey: "deviceConfig"),
+           let config = try? JSONDecoder().decode(DeviceConfig.self, from: data) {
+            return config
+        }
+        return .default
+    }
+
+    /// Fire-and-forget sync of barcode scan data.
+    static func syncBarcode(value: String, symbology: String) {
+        guard isEnabled else { return }
+        let config = deviceConfig
+        let payload: [String: Any] = [
+            "device_id": config.id,
+            "type": "barcode",
+            "data": [
+                "value": value,
+                "symbology": symbology,
+                "scanned_at": ISO8601DateFormatter().string(from: Date())
+            ]
+        ]
+        post(payload: payload, apiBaseURL: config.apiBaseURL)
+    }
+
+    /// Fire-and-forget sync of room scan data.
+    static func syncRoom(roomName: String, summaryJSON: Data) {
+        guard isEnabled else { return }
+        let config = deviceConfig
+        let summaryDict = (try? JSONSerialization.jsonObject(with: summaryJSON)) as? [String: Any] ?? [:]
+        let payload: [String: Any] = [
+            "device_id": config.id,
+            "type": "room",
+            "data": [
+                "room_name": roomName,
+                "summary": summaryDict
+            ]
+        ]
+        post(payload: payload, apiBaseURL: config.apiBaseURL)
+    }
+
+    private static func post(payload: [String: Any], apiBaseURL: String) {
+        guard let url = URL(string: apiBaseURL + "/api/debug/sync") else { return }
+        guard let body = try? JSONSerialization.data(withJSONObject: payload) else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = body
+
+        URLSession.shared.dataTask(with: request).resume()
+    }
+}
+#endif

--- a/ios/Robo/Views/BarcodeDetailView.swift
+++ b/ios/Robo/Views/BarcodeDetailView.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+
+struct BarcodeDetailView: View {
+    let scan: ScanRecord
+
+    @State private var copiedToastVisible = false
+
+    var body: some View {
+        List {
+            Section {
+                Text(scan.barcodeValue)
+                    .font(.title2.monospaced())
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.vertical, 8)
+            }
+
+            Section {
+                LabeledContent("Symbology", value: formatSymbology(scan.symbology))
+                LabeledContent("Scanned") {
+                    Text(scan.capturedAt, format: .dateTime)
+                }
+            }
+
+            Section {
+                Button {
+                    UIPasteboard.general.string = scan.barcodeValue
+                    copiedToastVisible = true
+                    Task {
+                        try? await Task.sleep(for: .seconds(1.5))
+                        copiedToastVisible = false
+                    }
+                } label: {
+                    Label("Copy to Clipboard", systemImage: "doc.on.doc")
+                }
+            }
+        }
+        .navigationTitle("Barcode")
+        .navigationBarTitleDisplayMode(.inline)
+        .overlay(alignment: .bottom) {
+            if copiedToastVisible {
+                Text("Copied to clipboard")
+                    .font(.caption)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                    .background(.ultraThinMaterial)
+                    .clipShape(Capsule())
+                    .padding(.bottom, 8)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
+        }
+        .animation(.easeInOut(duration: 0.2), value: copiedToastVisible)
+    }
+
+    private func formatSymbology(_ raw: String) -> String {
+        raw.replacingOccurrences(of: "VNBarcodeSymbology", with: "")
+    }
+}

--- a/ios/Robo/Views/BarcodeScannerView.swift
+++ b/ios/Robo/Views/BarcodeScannerView.swift
@@ -113,6 +113,10 @@ struct BarcodeScannerView: View {
             self.error = "Failed to save scan: \(error.localizedDescription)"
         }
 
+        #if DEBUG
+        DebugSyncService.syncBarcode(value: code, symbology: symbology)
+        #endif
+
         // Show toast (replaces previous)
         currentToast = ToastItem(code: code, symbology: symbology)
 

--- a/ios/Robo/Views/LiDARScanView.swift
+++ b/ios/Robo/Views/LiDARScanView.swift
@@ -185,6 +185,10 @@ struct LiDARScanView: View {
             modelContext.insert(record)
             try modelContext.save()
 
+            #if DEBUG
+            DebugSyncService.syncRoom(roomName: name, summaryJSON: summaryData)
+            #endif
+
             dismiss()
         } catch {
             self.error = "Failed to save: \(error.localizedDescription)"

--- a/ios/Robo/Views/RoomDetailView.swift
+++ b/ios/Robo/Views/RoomDetailView.swift
@@ -1,0 +1,168 @@
+import SwiftUI
+
+struct RoomDetailView: View {
+    let room: RoomScanRecord
+
+    @State private var shareURL: URL?
+
+    private var summary: [String: Any]? {
+        try? JSONSerialization.jsonObject(with: room.summaryJSON) as? [String: Any]
+    }
+
+    var body: some View {
+        List {
+            Section {
+                VStack(spacing: 4) {
+                    Text(room.roomName)
+                        .font(.title2.bold())
+                    Text(room.capturedAt, format: .dateTime)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 4)
+            }
+
+            floorPlanSection
+
+            metricsSection
+
+            fileSizeSection
+
+            Section {
+                Button {
+                    exportRoom()
+                } label: {
+                    Label("Share as ZIP", systemImage: "square.and.arrow.up")
+                }
+            }
+        }
+        .navigationTitle("Room Scan")
+        .navigationBarTitleDisplayMode(.inline)
+        .sheet(isPresented: Binding(
+            get: { shareURL != nil },
+            set: { if !$0 { shareURL = nil } }
+        )) {
+            if let shareURL {
+                ActivityView(activityItems: [shareURL])
+            }
+        }
+    }
+
+    // MARK: - Floor Plan
+
+    @ViewBuilder
+    private var floorPlanSection: some View {
+        if let summary,
+           let lengthM = summary["room_length_m"] as? Double,
+           let widthM = summary["room_width_m"] as? Double {
+            let lengthFt = lengthM * RoomDataProcessor.metersToFeet
+            let widthFt = widthM * RoomDataProcessor.metersToFeet
+
+            Section("Floor Plan") {
+                Canvas { context, size in
+                    let padding: CGFloat = 40
+                    let available = CGSize(
+                        width: size.width - padding * 2,
+                        height: size.height - padding * 2
+                    )
+                    let scale = min(
+                        available.width / CGFloat(lengthFt),
+                        available.height / CGFloat(widthFt)
+                    )
+                    let rectW = CGFloat(lengthFt) * scale
+                    let rectH = CGFloat(widthFt) * scale
+                    let origin = CGPoint(
+                        x: (size.width - rectW) / 2,
+                        y: (size.height - rectH) / 2
+                    )
+                    let rect = CGRect(origin: origin, size: CGSize(width: rectW, height: rectH))
+
+                    // Draw room rectangle
+                    let path = Path(roundedRect: rect, cornerRadius: 4)
+                    context.stroke(path, with: .color(.accentColor), lineWidth: 2)
+                    context.fill(path, with: .color(.accentColor.opacity(0.08)))
+
+                    // Length label (bottom)
+                    let lengthLabel = String(format: "%.1f ft", lengthFt)
+                    context.draw(
+                        Text(lengthLabel).font(.caption.bold()).foregroundColor(.primary),
+                        at: CGPoint(x: size.width / 2, y: rect.maxY + 16)
+                    )
+
+                    // Width label (right)
+                    let widthLabel = String(format: "%.1f ft", widthFt)
+                    context.draw(
+                        Text(widthLabel).font(.caption.bold()).foregroundColor(.primary),
+                        at: CGPoint(x: rect.maxX + 24, y: size.height / 2)
+                    )
+                }
+                .frame(height: 200)
+            }
+        }
+    }
+
+    // MARK: - Metrics
+
+    @ViewBuilder
+    private var metricsSection: some View {
+        let dict = summary ?? [:]
+        let floorAreaSqft = room.floorAreaSqM * RoomDataProcessor.sqmToSqft
+        let ceilFt = room.ceilingHeightM * RoomDataProcessor.metersToFeet
+        let doorCount = dict["door_count"] as? Int ?? 0
+        let windowCount = dict["window_count"] as? Int ?? 0
+
+        Section("Metrics") {
+            LabeledContent("Floor Area", value: String(format: "%.0f ft\u{00B2}", floorAreaSqft))
+            if room.ceilingHeightM > 0 {
+                LabeledContent("Ceiling Height", value: String(format: "%.1f ft", ceilFt))
+            }
+            LabeledContent("Walls", value: "\(room.wallCount)")
+            LabeledContent("Doors", value: "\(doorCount)")
+            LabeledContent("Windows", value: "\(windowCount)")
+            LabeledContent("Objects", value: "\(room.objectCount)")
+            if let shape = dict["room_shape"] as? String {
+                LabeledContent("Shape", value: shape.capitalized)
+            }
+        }
+    }
+
+    // MARK: - File Sizes
+
+    @ViewBuilder
+    private var fileSizeSection: some View {
+        Section("Data") {
+            LabeledContent("Summary", value: formatBytes(room.summaryJSON.count))
+            LabeledContent("Full Room Data", value: formatBytes(room.fullRoomDataJSON.count))
+        }
+    }
+
+    // MARK: - Actions
+
+    private func exportRoom() {
+        Task.detached {
+            do {
+                let url = try ExportService.createRoomExportZipFromData(
+                    roomName: room.roomName,
+                    summaryJSON: room.summaryJSON,
+                    fullRoomDataJSON: room.fullRoomDataJSON
+                )
+                await MainActor.run {
+                    shareURL = url
+                }
+            } catch {
+                // Silently fail — export is best-effort
+            }
+        }
+    }
+
+    private func formatBytes(_ bytes: Int) -> String {
+        if bytes < 1024 {
+            return "\(bytes) B"
+        } else if bytes < 1024 * 1024 {
+            return String(format: "%.1f KB", Double(bytes) / 1024)
+        } else {
+            return String(format: "%.1f MB", Double(bytes) / (1024 * 1024))
+        }
+    }
+}

--- a/ios/Robo/Views/RoomResultView.swift
+++ b/ios/Robo/Views/RoomResultView.swift
@@ -16,7 +16,7 @@ struct RoomResultView: View {
     }
 
     private var floorAreaSqFt: Double {
-        floorArea * 10.7639
+        floorArea * RoomDataProcessor.sqmToSqft
     }
 
     private var ceilingHeight: Double {
@@ -24,7 +24,7 @@ struct RoomResultView: View {
     }
 
     private var ceilingHeightFt: Double {
-        ceilingHeight * 3.28084
+        ceilingHeight * RoomDataProcessor.metersToFeet
     }
 
     private var totalWallArea: Double {
@@ -32,7 +32,7 @@ struct RoomResultView: View {
     }
 
     private var totalWallAreaSqFt: Double {
-        totalWallArea * 10.7639
+        totalWallArea * RoomDataProcessor.sqmToSqft
     }
 
     private var roomDims: (length: Double, width: Double)? {
@@ -58,7 +58,7 @@ struct RoomResultView: View {
                 // Room dimensions headline
                 if let dims = roomDims {
                     VStack(spacing: 4) {
-                        Text(String(format: "%.0fft × %.0fft", dims.length * 3.28084, dims.width * 3.28084))
+                        Text(String(format: "%.0fft × %.0fft", dims.length * RoomDataProcessor.metersToFeet, dims.width * RoomDataProcessor.metersToFeet))
                             .font(.title.bold())
                         Text(String(format: "%.1f sq ft · %.1fft ceiling",
                                     floorAreaSqFt, ceilingHeightFt))

--- a/ios/Robo/Views/SettingsView.swift
+++ b/ios/Robo/Views/SettingsView.swift
@@ -5,6 +5,9 @@ struct SettingsView: View {
     @AppStorage("scanQuality") private var scanQuality: String = "balanced"
     @State private var apiURL: String = ""
     @State private var showingSaveConfirmation = false
+    #if DEBUG
+    @AppStorage("dev.syncToCloud") private var debugSyncEnabled = false
+    #endif
 
     var body: some View {
         NavigationStack {
@@ -34,6 +37,17 @@ struct SettingsView: View {
                     }
                     .disabled(apiURL == deviceService.config.apiBaseURL)
                 }
+
+                #if DEBUG
+                Section("Developer") {
+                    Toggle("Sync to Cloud", isOn: $debugSyncEnabled)
+                    if debugSyncEnabled {
+                        Text("Scan data uploads to debug endpoint after each save")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                #endif
 
                 Section("About") {
                     LabeledContent("Version", value: "1.0 (M1)")

--- a/ios/RoboTests/RoomDataProcessorTests.swift
+++ b/ios/RoboTests/RoomDataProcessorTests.swift
@@ -1,0 +1,151 @@
+import Testing
+import simd
+@testable import Robo
+
+// MARK: - Polygon Area (Shoelace Formula)
+
+@Test func polygonAreaSquare10x10() {
+    let corners: [simd_float3] = [
+        simd_float3(0, 0, 0),
+        simd_float3(10, 0, 0),
+        simd_float3(10, 0, 10),
+        simd_float3(0, 0, 10)
+    ]
+    let area = RoomDataProcessor.polygonArea(corners)
+    #expect(abs(area - 100.0) < 0.01)
+}
+
+@Test func polygonAreaRectangle3x4() {
+    let corners: [simd_float3] = [
+        simd_float3(0, 0, 0),
+        simd_float3(3, 0, 0),
+        simd_float3(3, 0, 4),
+        simd_float3(0, 0, 4)
+    ]
+    let area = RoomDataProcessor.polygonArea(corners)
+    #expect(abs(area - 12.0) < 0.01)
+}
+
+@Test func polygonAreaTriangle() {
+    // Right triangle with legs 3 and 4 = area 6
+    let corners: [simd_float3] = [
+        simd_float3(0, 0, 0),
+        simd_float3(3, 0, 0),
+        simd_float3(0, 0, 4)
+    ]
+    let area = RoomDataProcessor.polygonArea(corners)
+    #expect(abs(area - 6.0) < 0.01)
+}
+
+@Test func polygonAreaLShaped() {
+    // L-shape: 10x10 square minus 5x5 corner = 75 sqm
+    let corners: [simd_float3] = [
+        simd_float3(0, 0, 0),
+        simd_float3(10, 0, 0),
+        simd_float3(10, 0, 5),
+        simd_float3(5, 0, 5),
+        simd_float3(5, 0, 10),
+        simd_float3(0, 0, 10)
+    ]
+    let area = RoomDataProcessor.polygonArea(corners)
+    #expect(abs(area - 75.0) < 0.01)
+}
+
+@Test func polygonAreaWithNonZeroYCoordinates() {
+    // Y coordinate should be ignored (it's vertical height)
+    let corners: [simd_float3] = [
+        simd_float3(0, 1.5, 0),
+        simd_float3(5, 1.5, 0),
+        simd_float3(5, 1.5, 4),
+        simd_float3(0, 1.5, 4)
+    ]
+    let area = RoomDataProcessor.polygonArea(corners)
+    #expect(abs(area - 20.0) < 0.01)
+}
+
+@Test func polygonAreaTwoPointsReturnsZero() {
+    let corners: [simd_float3] = [
+        simd_float3(0, 0, 0),
+        simd_float3(5, 0, 0)
+    ]
+    let area = RoomDataProcessor.polygonArea(corners)
+    #expect(area == 0.0)
+}
+
+@Test func polygonAreaEmptyReturnsZero() {
+    let area = RoomDataProcessor.polygonArea([])
+    #expect(area == 0.0)
+}
+
+// MARK: - Bounding Box Dimensions
+
+@Test func boundingBoxSimpleRectangle() {
+    // 4 wall positions forming a rectangle
+    let positions: [(x: Double, z: Double)] = [
+        (x: 0, z: 0),
+        (x: 5, z: 0),
+        (x: 5, z: 3),
+        (x: 0, z: 3)
+    ]
+    let dims = RoomDataProcessor.boundingBoxDimensions(positions)
+    #expect(dims != nil)
+    #expect(abs(dims!.length - 5.0) < 0.01)
+    #expect(abs(dims!.width - 3.0) < 0.01)
+}
+
+@Test func boundingBoxTooFewPositionsReturnsNil() {
+    let positions: [(x: Double, z: Double)] = [
+        (x: 0, z: 0),
+        (x: 5, z: 0)
+    ]
+    let dims = RoomDataProcessor.boundingBoxDimensions(positions)
+    #expect(dims == nil)
+}
+
+@Test func boundingBoxLengthAlwaysGreaterOrEqualToWidth() {
+    let positions: [(x: Double, z: Double)] = [
+        (x: 0, z: 0),
+        (x: 2, z: 0),
+        (x: 2, z: 8),
+        (x: 0, z: 8)
+    ]
+    let dims = RoomDataProcessor.boundingBoxDimensions(positions)
+    #expect(dims != nil)
+    #expect(dims!.length >= dims!.width)
+    #expect(abs(dims!.length - 8.0) < 0.01)
+    #expect(abs(dims!.width - 2.0) < 0.01)
+}
+
+// MARK: - Perimeter Square Area
+
+@Test func perimeterSquareAreaFourEqualWalls() {
+    // 4 walls of 5m each = 20m perimeter, side = 5m, area = 25 sqm
+    let widths = [5.0, 5.0, 5.0, 5.0]
+    let area = RoomDataProcessor.perimeterSquareArea(widths)
+    #expect(abs(area - 25.0) < 0.01)
+}
+
+@Test func perimeterSquareAreaUnequalWalls() {
+    // Perimeter = 3+7+3+7 = 20m, side = 5m, area = 25 sqm
+    let widths = [3.0, 7.0, 3.0, 7.0]
+    let area = RoomDataProcessor.perimeterSquareArea(widths)
+    #expect(abs(area - 25.0) < 0.01)
+}
+
+@Test func perimeterSquareAreaEmptyReturnsZero() {
+    let area = RoomDataProcessor.perimeterSquareArea([])
+    #expect(area == 0.0)
+}
+
+// MARK: - Conversion Constants
+
+@Test func metersToFeetConversion() {
+    #expect(abs(RoomDataProcessor.metersToFeet - 3.28084) < 0.0001)
+}
+
+@Test func sqmToSqftConversion() {
+    // 1 sqm = 10.7639 sqft
+    let sqm = 100.0
+    let sqft = sqm * RoomDataProcessor.sqmToSqft
+    #expect(abs(sqft - 1076.39) < 0.01)
+}

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -57,3 +57,20 @@ targets:
         ITSAppUsesNonExemptEncryption: false
         NSCameraUsageDescription: "Robo needs camera access to scan barcodes, capture photos, and perform LiDAR room scanning for AI analysis"
         NSPhotoLibraryUsageDescription: "Robo needs photo library access to save captured images"
+
+  RoboTests:
+    type: bundle.unit-test
+    platform: iOS
+    sources:
+      - path: RoboTests
+        excludes:
+          - "**/.DS_Store"
+    dependencies:
+      - target: Robo
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.silv.Robo.tests
+        PRODUCT_MODULE_NAME: RoboTests
+        GENERATE_INFOPLIST_FILE: YES
+        TEST_HOST: "$(BUILT_PRODUCTS_DIR)/Robo.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Robo"
+        BUNDLE_LOADER: "$(TEST_HOST)"

--- a/workers/src/index.ts
+++ b/workers/src/index.ts
@@ -9,6 +9,7 @@ import { registerDevice, getDevice } from './routes/devices';
 import { submitSensorData } from './routes/sensors';
 import { getInbox, pushCard, respondToCard } from './routes/inbox';
 import { analyzeWithOpus } from './routes/opus';
+import { debugSync, debugList, debugGet } from './routes/debug';
 import { deviceAuth } from './middleware/deviceAuth';
 
 const app = new Hono<{ Bindings: Env }>();
@@ -37,6 +38,11 @@ app.post('/api/inbox/:card_id/respond', deviceAuth, respondToCard);
 
 // Opus integration
 app.post('/api/opus/analyze', analyzeWithOpus);
+
+// Debug sync (stores scan data in R2 for developer debugging)
+app.post('/api/debug/sync', debugSync);
+app.get('/api/debug/sync/:device_id', debugList);
+app.get('/api/debug/sync/:device_id/:key{.+}', debugGet);
 
 // Error handling
 app.onError((err, c) => {

--- a/workers/src/routes/debug.ts
+++ b/workers/src/routes/debug.ts
@@ -1,0 +1,61 @@
+import type { Context } from 'hono';
+import type { Env } from '../types';
+
+/**
+ * POST /api/debug/sync — Store debug scan data in R2
+ * Body: { device_id: string, type: "barcode" | "room", data: any }
+ */
+export async function debugSync(c: Context<{ Bindings: Env }>) {
+  const body = await c.req.json().catch(() => null);
+  if (!body || !body.device_id || !body.type || !body.data) {
+    return c.json({ error: 'Missing required fields: device_id, type, data' }, 400);
+  }
+
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const key = `debug/${body.device_id}/${timestamp}-${body.type}.json`;
+
+  await c.env.BUCKET.put(key, JSON.stringify(body.data, null, 2), {
+    customMetadata: {
+      device_id: body.device_id,
+      type: body.type,
+      uploaded_at: new Date().toISOString(),
+    },
+  });
+
+  return c.json({ ok: true, key });
+}
+
+/**
+ * GET /api/debug/sync/:device_id — List debug payloads for a device
+ */
+export async function debugList(c: Context<{ Bindings: Env }>) {
+  const deviceId = c.req.param('device_id');
+  const prefix = `debug/${deviceId}/`;
+
+  const listed = await c.env.BUCKET.list({ prefix, limit: 100 });
+  const items = listed.objects.map((obj) => ({
+    key: obj.key,
+    size: obj.size,
+    uploaded: obj.uploaded.toISOString(),
+    metadata: obj.customMetadata,
+  }));
+
+  return c.json({ device_id: deviceId, count: items.length, items });
+}
+
+/**
+ * GET /api/debug/sync/:device_id/:key+ — Retrieve a specific debug payload
+ */
+export async function debugGet(c: Context<{ Bindings: Env }>) {
+  const deviceId = c.req.param('device_id');
+  const key = c.req.param('key');
+  const fullKey = `debug/${deviceId}/${key}`;
+
+  const obj = await c.env.BUCKET.get(fullKey);
+  if (!obj) {
+    return c.json({ error: 'Not found' }, 404);
+  }
+
+  const data = await obj.json();
+  return c.json({ key: fullKey, data });
+}


### PR DESCRIPTION
## Summary
- **Fix floor area calculation** — rectangular fallback now uses the two largest dimensions instead of hardcoded `x * z`, which was wrong when Apple's floor surface had near-zero z (thickness axis)
- **Detail views** — tapping barcodes/rooms in history navigates to `BarcodeDetailView` (value, symbology, copy button) and `RoomDetailView` (metrics grid, 2D Canvas floor plan, share-as-ZIP)
- **Bulk export** — "Export All" toolbar button in History creates a combined ZIP (`barcodes/scans.json + scans.csv` + `rooms/{name}/summary + full`) and opens iOS share sheet
- **Unit test target** — `RoboTests` with 15 Swift Testing tests covering polygon area (shoelace formula), bounding box, perimeter-based area, and unit conversions
- **Debug sync** — `#if DEBUG` toggle in Settings that fire-and-forget POSTs scan data to `/api/debug/sync` Workers endpoint (R2 storage)
- **Conversion constants centralized** — `RoomDataProcessor.metersToFeet` and `.sqmToSqft` replace all hardcoded `3.28084` and `10.7639`
- **Rebased on PR #42** — includes deterministic SwiftData saves and concurrency isolation

## Test plan
- [x] 15 unit tests pass (`xcodebuild test -only-testing:RoboTests`)
- [x] Device build succeeds (`xcodebuild -destination 'generic/platform=iOS'`)
- [ ] Physical device: scan a known room, verify floor area within 5% of tape-measured
- [ ] Physical device: tap barcode in history → BarcodeDetailView opens
- [ ] Physical device: tap room in history → RoomDetailView opens with floor plan
- [ ] Physical device: Export All → share sheet with ZIP containing both sections
- [ ] Deploy Workers (`npm run deploy`) and test debug sync toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)