### PR TITLE
docs: solution docs for xcodegen swiftmodule conflict and RoomPlan axis bug

### DIFF
--- a/docs/solutions/build-errors/xcodegen-test-target-duplicate-swiftmodule-20260210.md
+++ b/docs/solutions/build-errors/xcodegen-test-target-duplicate-swiftmodule-20260210.md
@@ -1,0 +1,81 @@
+---
+title: "xcodegen test target produces duplicate swiftmodule — PRODUCT_MODULE_NAME fix"
+category: build-errors
+date: 2026-02-10
+component: ios
+tags: [xcodegen, unit-tests, swiftmodule, build-conflict, swift-testing]
+severity: blocking
+symptoms:
+  - "Multiple commands produce '...Robo.swiftmodule/arm64-apple-ios-simulator.swiftmodule'"
+  - "Target 'Robo' has copy command / Target 'RoboTests' has copy command"
+  - xcodebuild test fails on simulator but device build succeeds
+---
+
+# xcodegen Test Target Produces Duplicate swiftmodule
+
+## Problem
+
+Adding a `bundle.unit-test` target in xcodegen's `project.yml` causes `xcodebuild test` to fail with a "Multiple commands produce" error for `.swiftmodule` files. The device build (`generic/platform=iOS`) succeeds because it only builds the app target.
+
+## Symptoms
+
+```
+error: Multiple commands produce '.../Robo.swiftmodule/arm64-apple-ios-simulator.swiftmodule'
+    note: Target 'Robo' (project 'Robo') has copy command...
+    note: Target 'RoboTests' (project 'Robo') has copy command...
+```
+
+- Only occurs when running `xcodebuild test` (simulator)
+- Device-only builds succeed
+- Clean builds don't help
+
+## Root Cause
+
+The test target inherits `PRODUCT_NAME: Robo` from project-level settings in `project.yml`. Both the app target and the test target then produce a swiftmodule named `Robo.swiftmodule`, causing a build system collision.
+
+xcodegen propagates project-level `settings.base` to all targets. When the app target is named `Robo` and `PRODUCT_NAME` is set at the project level, the test target also gets `PRODUCT_NAME: Robo` unless explicitly overridden.
+
+## Solution
+
+Add `PRODUCT_MODULE_NAME: RoboTests` to the test target settings:
+
+```yaml
+# ios/project.yml
+  RoboTests:
+    type: bundle.unit-test
+    platform: iOS
+    sources:
+      - path: RoboTests
+        excludes:
+          - "**/.DS_Store"
+    dependencies:
+      - target: Robo
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.silv.Robo.tests
+        PRODUCT_MODULE_NAME: RoboTests          # <-- THIS FIXES IT
+        GENERATE_INFOPLIST_FILE: YES
+        TEST_HOST: "$(BUILT_PRODUCTS_DIR)/Robo.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Robo"
+        BUNDLE_LOADER: "$(TEST_HOST)"
+```
+
+Also requires `GENERATE_INFOPLIST_FILE: YES` — without it you get a separate "Cannot code sign because the target does not have an Info.plist file" error.
+
+After changing `project.yml`, regenerate:
+
+```bash
+cd ios && xcodegen generate
+```
+
+## Why This Works
+
+`PRODUCT_MODULE_NAME` overrides the module name derived from `PRODUCT_NAME`. By setting it to `RoboTests`, the test target produces `RoboTests.swiftmodule` instead of `Robo.swiftmodule`, eliminating the collision.
+
+## Prevention
+
+When adding test targets in xcodegen, always set `PRODUCT_MODULE_NAME` to a unique value distinct from the app target. A simple convention: `{AppName}Tests`.
+
+## Related
+
+- [Issue #40](https://github.com/mattsilv/robo/issues/40) — Add iOS test targets and CI gates
+- Apple Technical Note: [Resolving "Multiple commands produce" errors](https://developer.apple.com/documentation/xcode/build-system)

--- a/docs/solutions/logic-errors/roomplan-floor-area-wrong-axis-dimensions-20260210.md
+++ b/docs/solutions/logic-errors/roomplan-floor-area-wrong-axis-dimensions-20260210.md
@@ -1,0 +1,103 @@
+---
+title: "RoomPlan floor area incorrect — Surface.dimensions axis ambiguity"
+category: logic-errors
+date: 2026-02-10
+component: ios-lidar
+tags: [roomplan, lidar, floor-area, capturedroom, surface-dimensions, coordinate-system]
+severity: high
+symptoms:
+  - "Floor area wildly incorrect (off by 10x-100x)"
+  - "Rectangular fallback produces near-zero area"
+  - "dimensions.z is ~0.01 for floor surfaces"
+---
+
+# RoomPlan Floor Area Incorrect — Surface.dimensions Axis Ambiguity
+
+## Problem
+
+After LiDAR room scanning, the floor area calculation returns wildly incorrect values (e.g., 2 sq ft for a 150 sq ft room). This occurs when the scan produces floor surfaces with polygon corners that have fewer than 3 points, triggering the rectangular fallback path.
+
+## Symptoms
+
+- Floor area is orders of magnitude too small
+- Happens intermittently (depends on scan quality / number of polygon corners returned)
+- Wall count, ceiling height, and other metrics are correct
+- The rectangular fallback path fires instead of the shoelace formula path
+
+## Root Cause
+
+The rectangular fallback calculated floor area as:
+
+```swift
+floor.dimensions.x * floor.dimensions.z  // WRONG
+```
+
+For `CapturedRoom.Surface` objects of category `.floor`, Apple's `dimensions` property (`simd_float3`) does **not** map to a consistent coordinate system across surface categories:
+
+| Surface Category | dimensions.x | dimensions.y | dimensions.z |
+|-----------------|-------------|-------------|-------------|
+| Wall | width | height | thickness (~0.01) |
+| Floor | extent A | thickness (~0.01) | extent B |
+| *(varies)* | *(inconsistent)* | *(inconsistent)* | *(inconsistent)* |
+
+**The z-axis for floor surfaces often represents surface thickness (~0.01m), not a planar extent.** Apple's documentation does not clarify which axis maps to which physical dimension for each surface category.
+
+## Solution
+
+Instead of hardcoding axis pairs, take the **two largest** of the three dimension values:
+
+```swift
+// Before (broken):
+let area = Double(floor.dimensions.x) * Double(floor.dimensions.z)
+
+// After (correct):
+let w = Double(floor.dimensions.x)
+let h = Double(floor.dimensions.y)
+let d = Double(floor.dimensions.z)
+let sorted = [w, h, d].sorted().reversed()
+let dim1 = sorted[sorted.startIndex]
+let dim2 = sorted[sorted.index(after: sorted.startIndex)]
+let area = dim1 * dim2
+```
+
+This works regardless of which axis Apple assigns to thickness, because the thickness value (~0.01m) will always sort last.
+
+## Testing Strategy
+
+`CapturedRoom` and `CapturedRoom.Surface` have **no public initializers**, making direct unit testing impossible. The fix is to extract pure math functions that accept primitive types:
+
+```swift
+// Testable: accepts primitives, not CapturedRoom types
+static func polygonArea(_ corners: [simd_float3]) -> Double { ... }
+static func boundingBoxDimensions(_ positions: [(x: Double, z: Double)]) -> (length: Double, width: Double)? { ... }
+static func perimeterSquareArea(_ wallWidths: [Double]) -> Double { ... }
+```
+
+Then test with known geometric shapes:
+
+```swift
+@Test func polygonAreaSquare10x10() {
+    let corners: [simd_float3] = [
+        simd_float3(0, 0, 0), simd_float3(10, 0, 0),
+        simd_float3(10, 0, 10), simd_float3(0, 0, 10)
+    ]
+    #expect(abs(RoomDataProcessor.polygonArea(corners) - 100.0) < 0.01)
+}
+```
+
+## Prevention
+
+1. **Never hardcode axis pairs** for RoomPlan surface dimensions — Apple may change the mapping
+2. **Always use axis-agnostic math** (sort and take largest N values)
+3. **Add diagnostic logging** in DEBUG builds to catch axis issues early:
+   ```swift
+   #if DEBUG
+   print("[FloorArea] floor dims: x=\(floor.dimensions.x) y=\(floor.dimensions.y) z=\(floor.dimensions.z)")
+   #endif
+   ```
+
+## Related
+
+- [roomplan-floor-area-zero-sqft-fix](roomplan-floor-area-zero-sqft-fix-20260210.md) — Different bug: shoelace formula on unordered wall positions producing 0.0
+- [Issue #28](https://github.com/mattsilv/robo/issues/28) — LiDAR post-processing: dimensions, ceiling height, sq ft
+- [Apple RoomPlan docs](https://developer.apple.com/documentation/roomplan/capturedroom/surface)


### PR DESCRIPTION
## Summary
- **xcodegen test target duplicate swiftmodule** — documents the `PRODUCT_MODULE_NAME` fix for "Multiple commands produce" errors when adding unit test targets via xcodegen
- **RoomPlan floor area axis ambiguity** — documents Apple's undocumented `Surface.dimensions` axis mapping and the axis-agnostic fix (use two largest dimensions)

Both solutions include root cause analysis, code examples, prevention strategies, and cross-references to related issues and existing docs.

## Test plan
- [x] Docs only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)