### PR TITLE
feat: interactive 3D room viewer with 2D/3D toggle

### DIFF
--- a/ios/Robo/Views/Room3DView.swift
+++ b/ios/Robo/Views/Room3DView.swift
@@ -1,0 +1,332 @@
+import SwiftUI
+import SceneKit
+
+struct Room3DView: UIViewRepresentable {
+    let room: RoomScanRecord
+
+    func makeUIView(context: Context) -> SCNView {
+        let scnView = SCNView()
+        scnView.allowsCameraControl = true
+        scnView.antialiasingMode = .multisampling4X
+        scnView.backgroundColor = .clear
+        scnView.autoenablesDefaultLighting = false
+
+        let scene = buildScene()
+        scnView.scene = scene
+        return scnView
+    }
+
+    func updateUIView(_ uiView: SCNView, context: Context) {}
+
+    // MARK: - Scene Construction
+
+    private func buildScene() -> SCNScene {
+        let scene = SCNScene()
+
+        guard let summary = parseSummary() else { return scene }
+
+        let walls = summary.walls
+        let floorPolygon = summary.floorPolygon
+        let ceilingHeight = summary.ceilingHeight
+        let objects = summary.objects
+
+        // Compute centroid for camera targeting
+        let centroid = computeCentroid(walls: walls, floorPolygon: floorPolygon)
+
+        // Floor
+        if floorPolygon.count >= 3 {
+            let floorNode = makeFloorNode(polygon: floorPolygon)
+            scene.rootNode.addChildNode(floorNode)
+        }
+
+        // Walls
+        for wall in walls {
+            let wallNode = makeWallNode(wall: wall)
+            scene.rootNode.addChildNode(wallNode)
+
+            // Dimension label on wall
+            let label = makeLabelNode(text: formatFeetInches(wall.widthFt), position: SCNVector3(
+                Float(wall.centerX),
+                Float(wall.heightFt * 0.5 + 0.3),
+                Float(wall.centerZ)
+            ))
+            scene.rootNode.addChildNode(label)
+        }
+
+        // Ceiling (semi-transparent)
+        if ceilingHeight > 0, floorPolygon.count >= 3 {
+            let ceilingNode = makeCeilingNode(polygon: floorPolygon, height: ceilingHeight)
+            scene.rootNode.addChildNode(ceilingNode)
+        }
+
+        // Objects
+        for obj in objects {
+            let objNode = makeObjectNode(object: obj)
+            scene.rootNode.addChildNode(objNode)
+        }
+
+        // Lighting
+        addLighting(to: scene, centroid: centroid, ceilingHeight: ceilingHeight)
+
+        // Camera
+        addCamera(to: scene, centroid: centroid, ceilingHeight: ceilingHeight, walls: walls)
+
+        return scene
+    }
+
+    // MARK: - Parsing
+
+    private struct WallInfo {
+        let centerX: Double
+        let centerZ: Double
+        let widthFt: Double
+        let heightFt: Double
+        let rotationDeg: Double
+    }
+
+    private struct ObjectInfo {
+        let category: String
+        let centerX: Double
+        let centerZ: Double
+        let widthFt: Double
+        let depthFt: Double
+        let heightFt: Double
+    }
+
+    private struct RoomSummary {
+        let walls: [WallInfo]
+        let floorPolygon: [(x: Double, y: Double)]
+        let ceilingHeight: Double
+        let objects: [ObjectInfo]
+    }
+
+    private func parseSummary() -> RoomSummary? {
+        guard let dict = try? JSONSerialization.jsonObject(with: room.summaryJSON) as? [String: Any] else {
+            return nil
+        }
+
+        // Walls
+        let wallDicts = dict["walls"] as? [[String: Any]] ?? []
+        let walls = wallDicts.compactMap { w -> WallInfo? in
+            guard let cx = w["center_x_ft"] as? Double,
+                  let cz = w["center_y_ft"] as? Double,
+                  let width = w["width_ft"] as? Double,
+                  let height = w["height_ft"] as? Double,
+                  let rot = w["rotation_deg"] as? Double else { return nil }
+            return WallInfo(centerX: cx, centerZ: cz, widthFt: width, heightFt: height, rotationDeg: rot)
+        }
+
+        // Floor polygon
+        let polygonArray = dict["floor_polygon_2d_ft"] as? [[String: Double]] ?? []
+        let floorPolygon = polygonArray.compactMap { p -> (x: Double, y: Double)? in
+            guard let x = p["x"], let y = p["y"] else { return nil }
+            return (x: x, y: y)
+        }
+
+        let ceilingHeight = dict["ceiling_height_ft"] as? Double ?? 0
+
+        // Objects
+        let objDicts = dict["objects"] as? [[String: Any]] ?? []
+        let objects = objDicts.compactMap { o -> ObjectInfo? in
+            guard let cat = o["category"] as? String,
+                  let cx = o["center_x_ft"] as? Double,
+                  let cz = o["center_y_ft"] as? Double,
+                  let w = o["width_ft"] as? Double,
+                  let d = o["depth_ft"] as? Double,
+                  let h = o["height_ft"] as? Double else { return nil }
+            return ObjectInfo(category: cat, centerX: cx, centerZ: cz, widthFt: w, depthFt: d, heightFt: h)
+        }
+
+        return RoomSummary(walls: walls, floorPolygon: floorPolygon, ceilingHeight: ceilingHeight, objects: objects)
+    }
+
+    // MARK: - Node Builders
+
+    private func makeFloorNode(polygon: [(x: Double, y: Double)]) -> SCNNode {
+        let path = UIBezierPath()
+        path.move(to: CGPoint(x: polygon[0].x, y: polygon[0].y))
+        for i in 1..<polygon.count {
+            path.addLine(to: CGPoint(x: polygon[i].x, y: polygon[i].y))
+        }
+        path.close()
+
+        let shape = SCNShape(path: path, extrusionDepth: 0.05)
+        let material = SCNMaterial()
+        material.diffuse.contents = UIColor.systemBlue.withAlphaComponent(0.3)
+        material.isDoubleSided = true
+        shape.materials = [material]
+
+        let node = SCNNode(geometry: shape)
+        // SCNShape extrudes along Z, but floor should be in XZ plane
+        // Rotate -90 degrees around X to lay it flat
+        node.eulerAngles.x = -.pi / 2
+        return node
+    }
+
+    private func makeWallNode(wall: WallInfo) -> SCNNode {
+        let thickness: CGFloat = 0.3
+        let box = SCNBox(
+            width: CGFloat(wall.widthFt),
+            height: CGFloat(wall.heightFt),
+            length: thickness,
+            chamferRadius: 0
+        )
+        let material = SCNMaterial()
+        material.diffuse.contents = UIColor.systemGray4.withAlphaComponent(0.6)
+        material.isDoubleSided = true
+        box.materials = [material]
+
+        let node = SCNNode(geometry: box)
+        node.position = SCNVector3(
+            Float(wall.centerX),
+            Float(wall.heightFt / 2),
+            Float(wall.centerZ)
+        )
+        node.eulerAngles.y = Float(-wall.rotationDeg * .pi / 180)
+        return node
+    }
+
+    private func makeCeilingNode(polygon: [(x: Double, y: Double)], height: Double) -> SCNNode {
+        let path = UIBezierPath()
+        path.move(to: CGPoint(x: polygon[0].x, y: polygon[0].y))
+        for i in 1..<polygon.count {
+            path.addLine(to: CGPoint(x: polygon[i].x, y: polygon[i].y))
+        }
+        path.close()
+
+        let shape = SCNShape(path: path, extrusionDepth: 0.02)
+        let material = SCNMaterial()
+        material.diffuse.contents = UIColor.white.withAlphaComponent(0.15)
+        material.isDoubleSided = true
+        shape.materials = [material]
+
+        let node = SCNNode(geometry: shape)
+        node.eulerAngles.x = -.pi / 2
+        node.position.y = Float(height)
+        return node
+    }
+
+    private func makeObjectNode(object: ObjectInfo) -> SCNNode {
+        let box = SCNBox(
+            width: CGFloat(object.widthFt),
+            height: CGFloat(object.heightFt),
+            length: CGFloat(object.depthFt),
+            chamferRadius: 0.02
+        )
+        let material = SCNMaterial()
+        material.diffuse.contents = colorForCategory(object.category)
+        box.materials = [material]
+
+        let node = SCNNode(geometry: box)
+        node.position = SCNVector3(
+            Float(object.centerX),
+            Float(object.heightFt / 2),
+            Float(object.centerZ)
+        )
+        return node
+    }
+
+    private func makeLabelNode(text: String, position: SCNVector3) -> SCNNode {
+        let scnText = SCNText(string: text, extrusionDepth: 0.01)
+        scnText.font = UIFont.systemFont(ofSize: 0.35, weight: .bold)
+        scnText.flatness = 0.1
+        let material = SCNMaterial()
+        material.diffuse.contents = UIColor.white
+        scnText.materials = [material]
+
+        let node = SCNNode(geometry: scnText)
+        // Center the text at its position
+        let (min, max) = node.boundingBox
+        let dx = (max.x - min.x) / 2
+        let dy = (max.y - min.y) / 2
+        node.pivot = SCNMatrix4MakeTranslation(dx, dy, 0)
+        node.position = position
+        node.constraints = [SCNBillboardConstraint()]
+        return node
+    }
+
+    // MARK: - Camera & Lighting
+
+    private func addCamera(to scene: SCNScene, centroid: SCNVector3, ceilingHeight: Double, walls: [WallInfo]) {
+        let cameraNode = SCNNode()
+        cameraNode.camera = SCNCamera()
+        cameraNode.camera?.automaticallyAdjustsZRange = true
+
+        // Position: above and back from centroid
+        let roomSpan = estimateRoomSpan(walls: walls)
+        let distance = Float(max(roomSpan, 15)) * 1.2
+        cameraNode.position = SCNVector3(
+            centroid.x,
+            Float(max(ceilingHeight, 8)) * 1.5,
+            centroid.z + distance * 0.6
+        )
+        cameraNode.look(at: centroid)
+        scene.rootNode.addChildNode(cameraNode)
+    }
+
+    private func addLighting(to scene: SCNScene, centroid: SCNVector3, ceilingHeight: Double) {
+        // Ambient
+        let ambientNode = SCNNode()
+        ambientNode.light = SCNLight()
+        ambientNode.light?.type = .ambient
+        ambientNode.light?.intensity = 400
+        ambientNode.light?.color = UIColor.white
+        scene.rootNode.addChildNode(ambientNode)
+
+        // Directional (from above)
+        let dirNode = SCNNode()
+        dirNode.light = SCNLight()
+        dirNode.light?.type = .directional
+        dirNode.light?.intensity = 600
+        dirNode.light?.color = UIColor.white
+        dirNode.position = SCNVector3(centroid.x, Float(ceilingHeight) + 10, centroid.z)
+        dirNode.eulerAngles.x = -.pi / 3
+        scene.rootNode.addChildNode(dirNode)
+    }
+
+    // MARK: - Helpers
+
+    private func computeCentroid(walls: [WallInfo], floorPolygon: [(x: Double, y: Double)]) -> SCNVector3 {
+        if floorPolygon.count >= 3 {
+            let cx = floorPolygon.reduce(0.0) { $0 + $1.x } / Double(floorPolygon.count)
+            let cz = floorPolygon.reduce(0.0) { $0 + $1.y } / Double(floorPolygon.count)
+            return SCNVector3(Float(cx), 0, Float(cz))
+        }
+        guard !walls.isEmpty else { return SCNVector3Zero }
+        let cx = walls.reduce(0.0) { $0 + $1.centerX } / Double(walls.count)
+        let cz = walls.reduce(0.0) { $0 + $1.centerZ } / Double(walls.count)
+        return SCNVector3(Float(cx), 0, Float(cz))
+    }
+
+    private func estimateRoomSpan(walls: [WallInfo]) -> Double {
+        guard !walls.isEmpty else { return 10 }
+        let xs = walls.map(\.centerX)
+        let zs = walls.map(\.centerZ)
+        let dx = (xs.max() ?? 0) - (xs.min() ?? 0)
+        let dz = (zs.max() ?? 0) - (zs.min() ?? 0)
+        return max(dx, dz)
+    }
+
+    private func colorForCategory(_ category: String) -> UIColor {
+        switch category.lowercased() {
+        case "table": return .systemBrown.withAlphaComponent(0.7)
+        case "bed": return .systemBlue.withAlphaComponent(0.7)
+        case "sofa", "couch": return .systemGreen.withAlphaComponent(0.7)
+        case "chair": return .systemOrange.withAlphaComponent(0.7)
+        case "storage", "cabinet", "shelf": return .systemYellow.withAlphaComponent(0.7)
+        case "television", "tv", "screen": return .systemPurple.withAlphaComponent(0.7)
+        case "bathtub", "toilet", "sink": return .systemCyan.withAlphaComponent(0.7)
+        case "fireplace", "stove", "oven": return .systemRed.withAlphaComponent(0.7)
+        default: return .systemGray.withAlphaComponent(0.7)
+        }
+    }
+
+    private func formatFeetInches(_ feet: Double) -> String {
+        let wholeFeet = Int(feet)
+        let inches = Int((feet - Double(wholeFeet)) * 12.0 + 0.5)
+        if inches == 0 || inches == 12 {
+            return "\(inches == 12 ? wholeFeet + 1 : wholeFeet)\u{2032}"
+        }
+        return "\(wholeFeet)\u{2032}\(inches)\u{2033}"
+    }
+}

--- a/ios/Robo/Views/RoomDetailView.swift
+++ b/ios/Robo/Views/RoomDetailView.swift
@@ -1,9 +1,11 @@
 import SwiftUI
+import SceneKit
 
 struct RoomDetailView: View {
     let room: RoomScanRecord
 
     @State private var shareURL: URL?
+    @State private var show3D = false
 
     private var summary: [String: Any]? {
         try? JSONSerialization.jsonObject(with: room.summaryJSON) as? [String: Any]
@@ -53,53 +55,156 @@ struct RoomDetailView: View {
 
     @ViewBuilder
     private var floorPlanSection: some View {
-        if let summary,
-           let lengthM = summary["room_length_m"] as? Double,
-           let widthM = summary["room_width_m"] as? Double {
-            let lengthFt = lengthM * RoomDataProcessor.metersToFeet
-            let widthFt = widthM * RoomDataProcessor.metersToFeet
-
+        let hasPolygon = (floorPolygonPoints?.count ?? 0) >= 3
+        let hasRect = summary?["room_length_m"] as? Double != nil
+        if hasPolygon || hasRect {
             Section("Floor Plan") {
-                Canvas { context, size in
-                    let padding: CGFloat = 40
-                    let available = CGSize(
-                        width: size.width - padding * 2,
-                        height: size.height - padding * 2
-                    )
-                    let scale = min(
-                        available.width / CGFloat(lengthFt),
-                        available.height / CGFloat(widthFt)
-                    )
-                    let rectW = CGFloat(lengthFt) * scale
-                    let rectH = CGFloat(widthFt) * scale
-                    let origin = CGPoint(
-                        x: (size.width - rectW) / 2,
-                        y: (size.height - rectH) / 2
-                    )
-                    let rect = CGRect(origin: origin, size: CGSize(width: rectW, height: rectH))
-
-                    // Draw room rectangle
-                    let path = Path(roundedRect: rect, cornerRadius: 4)
-                    context.stroke(path, with: .color(.accentColor), lineWidth: 2)
-                    context.fill(path, with: .color(.accentColor.opacity(0.08)))
-
-                    // Length label (bottom)
-                    let lengthLabel = String(format: "%.1f ft", lengthFt)
-                    context.draw(
-                        Text(lengthLabel).font(.caption.bold()).foregroundColor(.primary),
-                        at: CGPoint(x: size.width / 2, y: rect.maxY + 16)
-                    )
-
-                    // Width label (right)
-                    let widthLabel = String(format: "%.1f ft", widthFt)
-                    context.draw(
-                        Text(widthLabel).font(.caption.bold()).foregroundColor(.primary),
-                        at: CGPoint(x: rect.maxX + 24, y: size.height / 2)
-                    )
+                Picker("View", selection: $show3D) {
+                    Text("2D").tag(false)
+                    Text("3D").tag(true)
                 }
-                .frame(height: 200)
+                .pickerStyle(.segmented)
+
+                if show3D {
+                    Room3DView(room: room)
+                        .frame(height: 300)
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                } else if let points = floorPolygonPoints, points.count >= 3 {
+                    polygonCanvas(points: points)
+                        .frame(height: 240)
+                } else if let summary,
+                          let lengthM = summary["room_length_m"] as? Double,
+                          let widthM = summary["room_width_m"] as? Double {
+                    rectangleCanvas(
+                        lengthFt: lengthM * RoomDataProcessor.metersToFeet,
+                        widthFt: widthM * RoomDataProcessor.metersToFeet
+                    )
+                    .frame(height: 240)
+                }
             }
         }
+    }
+
+    private var floorPolygonPoints: [(x: Double, y: Double)]? {
+        guard let summary,
+              let polygonArray = summary["floor_polygon_2d_ft"] as? [[String: Double]],
+              polygonArray.count >= 3 else { return nil }
+        let pts = polygonArray.compactMap { dict -> (x: Double, y: Double)? in
+            guard let x = dict["x"], let y = dict["y"] else { return nil }
+            return (x: x, y: y)
+        }
+        return pts.count >= 3 ? pts : nil
+    }
+
+    private func polygonCanvas(points: [(x: Double, y: Double)]) -> some View {
+        Canvas { context, size in
+            let padding: CGFloat = 44
+            let xs = points.map(\.x)
+            let ys = points.map(\.y)
+            let minX = xs.min()!, maxX = xs.max()!
+            let minY = ys.min()!, maxY = ys.max()!
+            let roomW = maxX - minX
+            let roomH = maxY - minY
+
+            let available = CGSize(width: size.width - padding * 2, height: size.height - padding * 2)
+            let scale = min(
+                available.width / CGFloat(max(roomW, 0.1)),
+                available.height / CGFloat(max(roomH, 0.1))
+            )
+            let scaledW = CGFloat(roomW) * scale
+            let scaledH = CGFloat(roomH) * scale
+            let offsetX = (size.width - scaledW) / 2 - CGFloat(minX) * scale
+            let offsetY = (size.height - scaledH) / 2 - CGFloat(minY) * scale
+
+            func tx(_ x: Double) -> CGFloat { CGFloat(x) * scale + offsetX }
+            func ty(_ y: Double) -> CGFloat { CGFloat(y) * scale + offsetY }
+
+            // Draw polygon
+            var path = Path()
+            path.move(to: CGPoint(x: tx(points[0].x), y: ty(points[0].y)))
+            for i in 1..<points.count {
+                path.addLine(to: CGPoint(x: tx(points[i].x), y: ty(points[i].y)))
+            }
+            path.closeSubpath()
+
+            context.stroke(path, with: .color(.accentColor), lineWidth: 2)
+            context.fill(path, with: .color(.accentColor.opacity(0.08)))
+
+            // Edge dimension labels
+            let cx = points.reduce(0.0) { $0 + $1.x } / Double(points.count)
+            let cy = points.reduce(0.0) { $0 + $1.y } / Double(points.count)
+
+            for i in 0..<points.count {
+                let j = (i + 1) % points.count
+                let p1 = points[i], p2 = points[j]
+                let length = sqrt(pow(p2.x - p1.x, 2) + pow(p2.y - p1.y, 2))
+                guard length > 0.3 else { continue }
+
+                let midX = (tx(p1.x) + tx(p2.x)) / 2
+                let midY = (ty(p1.y) + ty(p2.y)) / 2
+
+                let edgeMidRealX = (p1.x + p2.x) / 2
+                let edgeMidRealY = (p1.y + p2.y) / 2
+                let dx = edgeMidRealX - cx
+                let dy = edgeMidRealY - cy
+                let dist = sqrt(dx * dx + dy * dy)
+                let offset: CGFloat = 18
+                let ox = dist > 0.01 ? CGFloat(dx / dist) * offset : 0
+                let oy = dist > 0.01 ? CGFloat(dy / dist) * offset : 0
+
+                let label = formatFeetInches(length)
+                context.draw(
+                    Text(label).font(.caption2.bold()).foregroundColor(.primary),
+                    at: CGPoint(x: midX + ox, y: midY + oy)
+                )
+            }
+        }
+    }
+
+    private func rectangleCanvas(lengthFt: Double, widthFt: Double) -> some View {
+        Canvas { context, size in
+            let padding: CGFloat = 40
+            let available = CGSize(
+                width: size.width - padding * 2,
+                height: size.height - padding * 2
+            )
+            let scale = min(
+                available.width / CGFloat(lengthFt),
+                available.height / CGFloat(widthFt)
+            )
+            let rectW = CGFloat(lengthFt) * scale
+            let rectH = CGFloat(widthFt) * scale
+            let origin = CGPoint(
+                x: (size.width - rectW) / 2,
+                y: (size.height - rectH) / 2
+            )
+            let rect = CGRect(origin: origin, size: CGSize(width: rectW, height: rectH))
+
+            let path = Path(roundedRect: rect, cornerRadius: 4)
+            context.stroke(path, with: .color(.accentColor), lineWidth: 2)
+            context.fill(path, with: .color(.accentColor.opacity(0.08)))
+
+            let lengthLabel = String(format: "%.1f ft", lengthFt)
+            context.draw(
+                Text(lengthLabel).font(.caption.bold()).foregroundColor(.primary),
+                at: CGPoint(x: size.width / 2, y: rect.maxY + 16)
+            )
+
+            let widthLabel = String(format: "%.1f ft", widthFt)
+            context.draw(
+                Text(widthLabel).font(.caption.bold()).foregroundColor(.primary),
+                at: CGPoint(x: rect.maxX + 24, y: size.height / 2)
+            )
+        }
+    }
+
+    private func formatFeetInches(_ feet: Double) -> String {
+        let wholeFeet = Int(feet)
+        let inches = Int((feet - Double(wholeFeet)) * 12.0 + 0.5)
+        if inches == 0 || inches == 12 {
+            return "\(inches == 12 ? wholeFeet + 1 : wholeFeet)\u{2032}"
+        }
+        return "\(wholeFeet)\u{2032}\(inches)\u{2033}"
     }
 
     // MARK: - Metrics


### PR DESCRIPTION
## Summary
- New `Room3DView.swift` — SceneKit-based 3D visualization of room scans with orbit/pan/zoom gestures (`allowsCameraControl`)
- Segmented 2D/3D picker in `RoomDetailView` floor plan section
- Parses existing `summaryJSON` data (walls, floor polygon, ceiling height, objects) — no model changes needed

## Test plan
- [ ] Open a saved room scan, verify 2D view looks unchanged
- [ ] Toggle to 3D — walls, floor, and objects render correctly
- [ ] Drag to orbit, pinch to zoom in 3D view
- [ ] Dimension labels stay readable while rotating (billboard constraint)
- [ ] Test with both rectangular and L-shaped rooms

🤖 Generated with [Claude Code](https://claude.com/claude-code)