### PR TITLE
docs: CI TestFlight signing solution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,10 +144,20 @@ wrangler d1 migrations apply robo-db  # Run DB migrations
 wrangler deploy
 ```
 
-### iOS
-1. Archive in Xcode: Product → Archive
-2. Upload to App Store Connect
-3. Submit for TestFlight review
+### iOS (TestFlight)
+Auto-deploys to TestFlight on push to `main` when `ios/**` files change (via `.github/workflows/testflight.yml`). Can also trigger manually:
+```bash
+gh workflow run testflight.yml
+```
+Build number = `github.run_number + 100` (avoids collisions with local builds).
+
+**Required secrets** (all configured): `BUILD_CERTIFICATE_BASE64`, `P12_PASSWORD`, `KEYCHAIN_PASSWORD`, `APPSTORE_CONNECT_API_KEY_ID`, `APPSTORE_CONNECT_API_ISSUER_ID`, `APPSTORE_CONNECT_API_PRIVATE_KEY`
+
+### Landing Page
+```bash
+wrangler pages deploy site --project-name=robo-app --commit-dirty=true --branch=main
+```
+CI workflow (`deploy-site.yml`) removed for now — re-add with `CLOUDFLARE_API_TOKEN` secret when ready.
 
 ## Environment Variables
 

--- a/docs/solutions/build-errors/github-actions-testflight-ci-signing-20260211.md
+++ b/docs/solutions/build-errors/github-actions-testflight-ci-signing-20260211.md
@@ -1,0 +1,126 @@
+---
+title: "GitHub Actions TestFlight CI: Archive + Export Signing Failures"
+category: build-errors
+component: ci/cd
+date: 2026-02-11
+symptoms:
+  - "CompileAssetCatalog: No simulator runtime version available"
+  - "exportArchive Cloud signing permission error"
+  - "exportArchive No profiles for 'com.silv.Robo' were found"
+root_causes:
+  - Xcode 16.2 actool requires simulator runtime even for device archives
+  - App Store Connect API key lacks Admin role for cloud signing
+  - "-allowProvisioningUpdates unreliable on ephemeral CI runners"
+resolution: install-simulator-runtime, explicit-provisioning-profile, admin-api-key
+---
+
+# GitHub Actions TestFlight CI: Archive + Export Signing Failures
+
+## Problem
+
+Three cascading failures when setting up `testflight.yml` on GitHub Actions with `macos-15` runner + Xcode 16.2:
+
+### Failure 1: Asset Catalog SDK Mismatch (Archive)
+```
+error: No simulator runtime version from [22F77, 22G86, 23B86, 23C54]
+available to use with iphonesimulator SDK version 22C146
+```
+
+### Failure 2: Cloud Signing Permission (Export)
+```
+error: exportArchive Cloud signing permission error
+```
+
+### Failure 3: Missing Provisioning Profile (Export)
+```
+error: exportArchive No profiles for 'com.silv.Robo' were found
+```
+
+## Root Causes
+
+| Failure | Root Cause |
+|---------|-----------|
+| Asset catalog | `actool` resolves simulator SDKs even for device builds; `macos-15` runner's pre-installed runtimes don't match Xcode 16.2's SDK |
+| Cloud signing | API key had Developer role, not Admin (required for cloud signing) |
+| No profiles | `-allowProvisioningUpdates` is [unreliable on ephemeral runners](https://developer.apple.com/forums/thread/688626) — can't auto-create distribution profiles with API-key-only auth |
+
+### Why Local Deploy Works But CI Doesn't
+
+| Aspect | Local | CI |
+|--------|-------|-----|
+| Auth | Full Xcode account session | API key (.p8) only |
+| Cloud signing | Xcode session has full access | Fails without Admin key |
+| Profile creation | Auto-created via Xcode session | Can't auto-create on ephemeral runner |
+| Simulator runtimes | All installed with Xcode | Mismatched on `macos-15` runner |
+
+## Solution
+
+### Fix 1: Install iOS Simulator Runtime
+```yaml
+- name: Install iOS simulator runtime
+  run: xcodebuild -downloadPlatform iOS -quiet || true
+```
+Plus add `-sdk iphoneos` to the `xcodebuild archive` command.
+
+### Fix 2: Create Admin API Key
+1. Go to https://appstoreconnect.apple.com/access/integrations/api
+2. Create new key with **Admin** role
+3. Download `.p8` immediately (only available once)
+4. Update secrets: `APPSTORE_CONNECT_API_KEY_ID`, `APPSTORE_CONNECT_API_PRIVATE_KEY`
+
+### Fix 3: Install Explicit Provisioning Profile
+1. Create App Store Distribution profile at https://developer.apple.com/account/resources/profiles/list
+2. Base64-encode and upload:
+   ```bash
+   base64 -i profile.mobileprovision | gh secret set BUILD_PROVISION_PROFILE_BASE64
+   ```
+3. Add workflow step:
+   ```yaml
+   - name: Install provisioning profile
+     env:
+       BUILD_PROVISION_PROFILE_BASE64: ${{ secrets.BUILD_PROVISION_PROFILE_BASE64 }}
+     run: |
+       PP_PATH=$RUNNER_TEMP/build_pp.mobileprovision
+       echo -n "$BUILD_PROVISION_PROFILE_BASE64" | base64 --decode -o "$PP_PATH"
+       mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+       cp "$PP_PATH" ~/Library/MobileDevice/Provisioning\ Profiles
+   ```
+
+### Required Secrets (7 total)
+| Secret | Purpose |
+|--------|---------|
+| `BUILD_CERTIFICATE_BASE64` | Apple Distribution cert (.p12), base64 |
+| `P12_PASSWORD` | Password for the .p12 file |
+| `KEYCHAIN_PASSWORD` | Temp keychain password (any value) |
+| `BUILD_PROVISION_PROFILE_BASE64` | App Store provisioning profile, base64 |
+| `APPSTORE_CONNECT_API_KEY_ID` | API key ID (must be Admin role) |
+| `APPSTORE_CONNECT_API_ISSUER_ID` | Issuer UUID from App Store Connect |
+| `APPSTORE_CONNECT_API_PRIVATE_KEY` | Contents of AuthKey_*.p8 file |
+
+## Investigation Timeline
+
+1. `xcpretty || true` masked real errors — replaced with `tee` + `tail` for raw logs
+2. `-sdk iphoneos` didn't fix actool alone — needed simulator runtime install too
+3. Archive passed after runtime fix — export then failed with new signing errors
+4. Distribution cert uploaded — export still failed (cloud signing permission)
+5. Provisioning profile added + Admin API key — **build succeeded**
+
+## Prevention
+
+- Always use explicit provisioning profile on CI (don't rely on `-allowProvisioningUpdates` for export)
+- API keys for CI must have **Admin** role
+- Never pipe xcodebuild through `xcpretty || true` — it swallows errors
+- Store `.p8` keys in `.gitignore` (`**/*.p8`, `private_keys/`)
+
+## Related Docs
+
+- [homebrew-rsync-xcode-export-archive-fix](homebrew-rsync-xcode-export-archive-fix-20260210.md) — PATH stripping for local exports
+- [testflight-cli-export-copy-failed](testflight-cli-export-copy-failed-20260210.md) — Missing distribution cert locally
+- [testflight-encryption-compliance-bypass](testflight-encryption-compliance-bypass-20260210.md) — ITSAppUsesNonExemptEncryption
+
+## References
+
+- [GitHub Docs: Installing Apple cert on CI](https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development)
+- [WWDC21: Cloud signing](https://developer.apple.com/videos/play/wwdc2021/10204/)
+- [Apple Forums: exportArchive fails on CI](https://developer.apple.com/forums/thread/688626)
+- [Fastlane: Cloud signing limitations](https://github.com/fastlane/fastlane/discussions/19973)

--- a/plans/fix-ci-testflight-signing.md
+++ b/plans/fix-ci-testflight-signing.md
@@ -1,0 +1,78 @@
+# Fix CI TestFlight Signing
+
+## Problem
+
+`testflight.yml` archive succeeds but export fails:
+```
+error: exportArchive Cloud signing permission error
+error: exportArchive No profiles for 'com.silv.Robo' were found
+```
+
+## Root Cause
+
+Two issues discovered by research agents:
+
+1. **"Cloud signing permission error"** — The App Store Connect API key may not have **Admin** role (required for cloud signing). Developer/App Manager roles fail silently.
+
+2. **Provisioning profile not available** — `-allowProvisioningUpdates` with API key auth is [unreliable on ephemeral CI runners](https://developer.apple.com/forums/thread/688626). Cloud signing works locally because Xcode has a full account session; on CI with just an API key, the export phase frequently can't auto-create/download the distribution profile.
+
+## Fix (Two Steps)
+
+### Step 1: Verify API key has Admin role
+- [ ] Go to https://appstoreconnect.apple.com/access/integrations/api
+- [ ] Check the API key used for CI has **Admin** access (not Developer or App Manager)
+- [ ] If not Admin, create a new key with Admin role and update secrets:
+  - `APPSTORE_CONNECT_API_KEY_ID`
+  - `APPSTORE_CONNECT_API_PRIVATE_KEY`
+
+### Step 2: Add explicit provisioning profile (belt-and-suspenders)
+
+Even with Admin API key, explicit profile is more reliable on ephemeral runners.
+
+- [ ] Go to https://developer.apple.com/account/resources/profiles/list
+- [ ] Create/download **App Store Distribution** profile for `com.silv.Robo`
+  - Type: App Store Connect
+  - App ID: com.silv.Robo
+  - Certificate: Apple Distribution: OtoCo DE LLC (R3Z5CY34Q5)
+- [ ] Base64-encode and add as secret:
+  ```bash
+  base64 -i ~/Downloads/Robo_AppStore.mobileprovision | gh secret set BUILD_PROVISION_PROFILE_BASE64 --repo mattsilv/robo
+  ```
+- [ ] Add workflow step in `testflight.yml` (after cert install, before archive):
+  ```yaml
+  - name: Install provisioning profile
+    env:
+      BUILD_PROVISION_PROFILE_BASE64: ${{ secrets.BUILD_PROVISION_PROFILE_BASE64 }}
+    run: |
+      PP_PATH=$RUNNER_TEMP/build_pp.mobileprovision
+      echo -n "$BUILD_PROVISION_PROFILE_BASE64" | base64 --decode -o "$PP_PATH"
+      mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+      cp "$PP_PATH" ~/Library/MobileDevice/Provisioning\ Profiles
+  ```
+- [ ] Add cleanup in the Cleanup step:
+  ```yaml
+  rm -f ~/Library/MobileDevice/Provisioning\ Profiles/build_pp.mobileprovision
+  ```
+
+### Step 3: Test
+- [ ] `gh workflow run testflight.yml`
+- [ ] Verify export + upload succeeds
+
+## Why Local Deploy Works
+
+| Aspect | Local (works) | CI (fails) |
+|--------|--------------|------------|
+| Auth | Full Xcode account session | API key only |
+| Cloud signing | Xcode session has full access | "Cloud signing permission error" |
+| Profile | Auto-created via Xcode session | Can't auto-create with API key |
+
+## Optional: Remove simulator runtime download
+
+The `xcodebuild -downloadPlatform iOS` step adds ~5 min to builds. With `-sdk iphoneos` set, it may no longer be needed. Test removing it after signing is fixed.
+
+## References
+
+- [GitHub Docs: Installing Apple cert on CI](https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development)
+- [WWDC21: Cloud signing](https://developer.apple.com/videos/play/wwdc2021/10204/)
+- [Apple Forums: exportArchive fails on CI](https://developer.apple.com/forums/thread/688626)
+- [Fastlane: Cloud signing limitations](https://github.com/fastlane/fastlane/discussions/19973)


### PR DESCRIPTION
## Summary
- Solution doc for 3 cascading GitHub Actions TestFlight failures (actool SDK mismatch, cloud signing permission, missing provisioning profile)
- Plan doc used during the fix
- Updated CLAUDE.md Deployment section with CI workflow, manual trigger, and required secrets

## Context
CI TestFlight pipeline is now fully working after fixing:
1. Asset catalog compilation (install simulator runtime + explicit `-sdk iphoneos`)
2. Cloud signing (Admin API key required)
3. Profile resolution (explicit provisioning profile install)

## Test plan
- [x] CI TestFlight build succeeds: https://github.com/mattsilv/robo/actions/runs/21908896176

🤖 Generated with [Claude Code](https://claude.com/claude-code)