### PR TITLE
fix: address PR #73 review feedback

### DIFF
--- a/ios/Robo/RoboApp.swift
+++ b/ios/Robo/RoboApp.swift
@@ -50,10 +50,15 @@ struct RoboApp: App {
         do {
             if FileManager.default.fileExists(atPath: storeURL.path) {
                 try FileManager.default.copyItem(at: storeURL, to: backupURL)
+                // Also backup WAL/SHM sidecars for complete recovery
+                for suffix in ["-wal", "-shm"] {
+                    let sidecar = URL(fileURLWithPath: storeURL.path + suffix)
+                    let sidecarBackup = URL(fileURLWithPath: backupURL.path + suffix)
+                    try? FileManager.default.copyItem(at: sidecar, to: sidecarBackup)
+                }
                 logger.warning("Backed up corrupt store to \(backupURL.lastPathComponent)")
-                // Remove original only AFTER successful backup
+                // Remove originals only AFTER successful backup
                 try FileManager.default.removeItem(at: storeURL)
-                // Also remove WAL/SHM if present
                 for suffix in ["-wal", "-shm"] {
                     let sidecar = URL(fileURLWithPath: storeURL.path + suffix)
                     try? FileManager.default.removeItem(at: sidecar)

--- a/ios/Robo/Views/ScanHistoryView.swift
+++ b/ios/Robo/Views/ScanHistoryView.swift
@@ -130,7 +130,7 @@ struct ScanHistoryView: View {
                 }
                 .onDelete(perform: deleteBarcodeScans)
 
-                exportAllSection(count: scans.count, label: "barcodes")
+                exportAllSection
             }
         }
     }
@@ -184,7 +184,7 @@ struct ScanHistoryView: View {
                 }
                 .onDelete(perform: deleteRoomScans)
 
-                exportAllSection(count: roomScans.count, label: "rooms")
+                exportAllSection
             }
         }
     }
@@ -223,15 +223,19 @@ struct ScanHistoryView: View {
                 }
                 .onDelete(perform: deleteMotionRecords)
 
-                exportAllSection(count: motionRecords.count, label: "records")
+                exportAllSection
             }
         }
     }
 
     // MARK: - Export All Section
 
+    private var totalItemCount: Int {
+        scans.count + roomScans.count + motionRecords.count
+    }
+
     @ViewBuilder
-    private func exportAllSection(count: Int, label: String) -> some View {
+    private var exportAllSection: some View {
         Section {
             Button {
                 exportAll()
@@ -242,7 +246,7 @@ struct ScanHistoryView: View {
                         ProgressView()
                             .padding(.trailing, 8)
                     }
-                    Label("Export All (\(count))", systemImage: "square.and.arrow.up")
+                    Label("Export All Data (\(totalItemCount))", systemImage: "square.and.arrow.up")
                     Spacer()
                 }
             }


### PR DESCRIPTION
## Summary

Addresses all 4 review findings from PR #73 code review:

- **[P1] validate-build.sh false positive**: Replaced line-by-line `grep -v "backup"` with pattern check — flags deletion only when no `copyItem` exists in the file. No more false positives on the safe backup-then-delete path.
- **[P2] fatalError guardrail multiline**: Replaced single-line keyword grep with count-based check — total `fatalError` calls must not exceed `unrecoverable` marker count. Works regardless of line breaks.
- **[P2] WAL/SHM backup**: Added `copyItem` for `-wal` and `-shm` sidecars before deleting them, ensuring complete backup in WAL mode.
- **[P3] Export All label mismatch**: Changed "Export All (N)" to "Export All Data (N)" with total count across all data types (barcodes + rooms + motion), matching the actual global export behavior.

Closes #74 #75 #76 #77

## Test plan
- [ ] Run `scripts/validate-build.sh` — checks 6 and 7 should PASS without false positives
- [ ] Build with 0 errors, 0 warnings (verified locally)
- [ ] Visually confirm "Export All Data (N)" label in each history tab shows total count

🤖 Generated with [Claude Code](https://claude.com/claude-code)