### PR TITLE
Clarify AI agent messaging on landing page

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>ROBO.APP — Native Mobile Context for AI Agents</title>
-  <meta name="description" content="LiDAR, camera, and barcode data are trapped on your phone — invisible to AI agents. Robo unlocks them via webhooks, REST API, MCP, or simple email export. Open source, no iOS dev required.">
+  <title>ROBO.APP — Control your AI Context</title>
+  <meta name="description" content="Your phone has LiDAR, cameras, and barcode scanners. AI agents can't access any of it. Robo bridges the gap. Open source.">
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
@@ -15,18 +15,18 @@
   <!-- Open Graph / Facebook / Discord / iMessage -->
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://robo.app/">
-  <meta property="og:title" content="ROBO.APP — Native Mobile Context for AI Agents">
-  <meta property="og:description" content="LiDAR, camera, and barcode data are trapped on your phone. Robo unlocks them for AI agents — webhooks, REST, MCP, or email. Open source.">
+  <meta property="og:title" content="ROBO.APP — Control your AI Context">
+  <meta property="og:description" content="Your phone has LiDAR, cameras, and barcode scanners. AI agents can't access any of it. Robo bridges the gap. Open source.">
   <meta property="og:image" content="https://robo.app/og-image.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
-  <meta property="og:image:alt" content="ROBO.APP — Native mobile context for AI agents. Features: LiDAR, Barcode, Camera, HealthKit.">
+  <meta property="og:image:alt" content="ROBO.APP — One app for everything AI agents need from the real world.">
   <meta property="og:site_name" content="ROBO.APP">
 
   <!-- Twitter / X -->
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="ROBO.APP — Native Mobile Context for AI Agents">
-  <meta name="twitter:description" content="LiDAR, camera, and barcode data are trapped on your phone. Robo unlocks them for AI agents — webhooks, REST, MCP, or email. Open source.">
+  <meta name="twitter:title" content="ROBO.APP — Control your AI Context">
+  <meta name="twitter:description" content="Your phone has LiDAR, cameras, and barcode scanners. AI agents can't access any of it. Robo bridges the gap. Open source.">
   <meta name="twitter:image" content="https://robo.app/og-image.png">
   <meta name="twitter:creator" content="@mattsilv">
 
@@ -44,9 +44,13 @@
       --blue-light: #3b82f6;
       --blue-glow: rgba(37, 99, 235, 0.35);
       --blue-dim: rgba(37, 99, 235, 0.12);
+      --purple: #7c3aed;
+      --purple-dim: rgba(124, 58, 237, 0.12);
       --bg: #06060a;
       --surface: #0d0d14;
+      --surface-raised: #12121c;
       --border: rgba(255,255,255,0.06);
+      --border-accent: rgba(37, 99, 235, 0.2);
       --text: #e2e2e8;
       --text-dim: #6b6b7b;
       --text-muted: #3d3d4d;
@@ -67,7 +71,7 @@
       position: relative;
     }
 
-    /* ── dot grid background ── */
+    /* -- dot grid background -- */
     body::before {
       content: '';
       position: fixed;
@@ -78,7 +82,7 @@
       z-index: 0;
     }
 
-    /* ── ambient glow ── */
+    /* -- ambient glow -- */
     body::after {
       content: '';
       position: fixed;
@@ -99,7 +103,7 @@
       50% { opacity: 0.6; transform: translateX(-50%) scale(1.1); }
     }
 
-    /* ── main container ── */
+    /* -- main container -- */
     .container {
       position: relative;
       z-index: 1;
@@ -112,7 +116,7 @@
       gap: 0;
     }
 
-    /* ── staggered fade-in ── */
+    /* -- staggered fade-in -- */
     .fade-in {
       opacity: 0;
       transform: translateY(16px);
@@ -128,12 +132,14 @@
     .fade-in:nth-child(8) { animation-delay: 0.8s }
     .fade-in:nth-child(9) { animation-delay: 0.9s }
     .fade-in:nth-child(10) { animation-delay: 1.0s }
+    .fade-in:nth-child(11) { animation-delay: 1.1s }
+    .fade-in:nth-child(12) { animation-delay: 1.2s }
 
     @keyframes fadeUp {
       to { opacity: 1; transform: translateY(0); }
     }
 
-    /* ── robot icon ── */
+    /* -- robot icon -- */
     .robot-wrap {
       margin-bottom: 1.75rem;
     }
@@ -150,14 +156,14 @@
       50% { transform: translateY(-8px); }
     }
 
-    /* ── wordmark ── */
+    /* -- wordmark -- */
     .wordmark {
       font-family: 'JetBrains Mono', monospace;
       font-weight: 800;
       font-size: 3rem;
       letter-spacing: 0.06em;
       color: #fff;
-      margin-bottom: 0.75rem;
+      margin-bottom: 0.5rem;
       line-height: 1;
     }
 
@@ -165,21 +171,31 @@
       color: var(--blue-light);
     }
 
-    /* ── tagline ── */
+    /* -- tagline -- */
     .tagline {
       font-family: 'JetBrains Mono', monospace;
       font-size: 0.85rem;
       font-weight: 400;
       color: var(--text-dim);
       letter-spacing: 0.02em;
-      margin-bottom: 2.25rem;
+      margin-bottom: 0.5rem;
       text-align: center;
       line-height: 1.5;
     }
 
-    /* ── badge ── */
+    .tagline-sub {
+      font-family: 'DM Sans', system-ui, sans-serif;
+      font-size: 1.15rem;
+      font-weight: 500;
+      color: var(--text);
+      text-align: center;
+      margin-bottom: 2rem;
+      line-height: 1.4;
+    }
+
+    /* -- badge -- */
     .badge-wrap {
-      margin-bottom: 2.5rem;
+      margin-bottom: 2.25rem;
     }
 
     .badge {
@@ -218,17 +234,409 @@
       50% { opacity: 0.3; }
     }
 
-    /* ── description ── */
+    /* -- demo -- */
+    .demo {
+      width: 100%;
+      max-width: 480px;
+      margin-bottom: 2.5rem;
+      min-height: 280px;
+    }
+
+    .demo__bubble {
+      display: none;
+      opacity: 0;
+      transform: translateY(8px);
+      transition: opacity 0.4s ease, transform 0.4s ease;
+      background: var(--surface);
+      border: 1px solid var(--border-accent);
+      border-radius: 12px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 0.75rem;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .demo__bubble::before {
+      content: '';
+      position: absolute;
+      top: 0; left: 0; right: 0;
+      height: 1px;
+      background: linear-gradient(90deg, transparent, var(--purple), transparent);
+      opacity: 0.3;
+    }
+
+    .demo__bubble.is-visible {
+      opacity: 1;
+      transform: translateY(0);
+    }
+
+    .demo__agent-row {
+      display: flex;
+      align-items: center;
+      gap: 0.6rem;
+      margin-bottom: 0.5rem;
+    }
+
+    .demo__agent-icon {
+      width: 32px;
+      height: 32px;
+      border-radius: 8px;
+      background: var(--purple-dim);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+    }
+
+    .demo__agent-icon svg {
+      width: 16px;
+      height: 16px;
+      stroke: var(--purple);
+    }
+
+    .demo__agent-name {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.68rem;
+      font-weight: 700;
+      color: var(--text-dim);
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+
+    .demo__bubble-text {
+      font-family: 'DM Sans', system-ui, sans-serif;
+      font-size: 0.95rem;
+      color: var(--text);
+      line-height: 1.5;
+      font-style: italic;
+    }
+
+    .demo__scanner {
+      display: none;
+      opacity: 0;
+      transform: scale(0.97);
+      transition: opacity 0.4s ease, transform 0.4s ease;
+      background: #0a0a0f;
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 1rem;
+      margin-bottom: 0.75rem;
+    }
+
+    .demo__scanner.is-visible {
+      opacity: 1;
+      transform: scale(1);
+    }
+
+    .demo__viewport {
+      position: relative;
+      height: 120px;
+      background: #050508;
+      border-radius: 8px;
+      overflow: hidden;
+      margin-bottom: 0.75rem;
+    }
+
+    .demo__viewport::after {
+      content: '';
+      position: absolute;
+      inset: 0;
+      border-radius: 8px;
+      box-shadow: inset 0 0 30px rgba(0, 0, 0, 0.5);
+      pointer-events: none;
+    }
+
+    .demo__corner {
+      position: absolute;
+      width: 20px;
+      height: 20px;
+      border-color: #22c55e;
+      border-style: solid;
+    }
+
+    .demo__corner--tl { top: 8px; left: 8px; border-width: 2px 0 0 2px; border-radius: 4px 0 0 0; }
+    .demo__corner--tr { top: 8px; right: 8px; border-width: 2px 2px 0 0; border-radius: 0 4px 0 0; }
+    .demo__corner--bl { bottom: 8px; left: 8px; border-width: 0 0 2px 2px; border-radius: 0 0 0 4px; }
+    .demo__corner--br { bottom: 8px; right: 8px; border-width: 0 2px 2px 0; border-radius: 0 0 4px 0; }
+
+    .demo__scan-line {
+      position: absolute;
+      left: 12px;
+      right: 12px;
+      height: 2px;
+      background: linear-gradient(90deg, transparent, #22c55e, transparent);
+      box-shadow: 0 0 8px rgba(34, 197, 94, 0.5);
+      opacity: 0;
+      top: 10%;
+      transition: opacity 0.3s ease;
+    }
+
+    .demo__scan-line.is-scanning {
+      opacity: 1;
+      animation: demoScanSweep 2s ease-in-out infinite;
+    }
+
+    .demo__barcode-overlay {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      width: 70%;
+      opacity: 0;
+      transition: opacity 0.5s ease;
+    }
+
+    .demo__barcode-overlay.is-visible {
+      opacity: 1;
+    }
+
+    .demo__barcode-overlay svg {
+      width: 100%;
+      height: auto;
+    }
+
+    @keyframes demoScanSweep {
+      0%, 100% { top: 10%; }
+      50% { top: 85%; }
+    }
+
+    .demo__items {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.4rem;
+      min-height: 28px;
+    }
+
+    .demo__item {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.68rem;
+      font-weight: 700;
+      color: #22c55e;
+      background: rgba(34, 197, 94, 0.1);
+      border: 1px solid rgba(34, 197, 94, 0.25);
+      border-radius: 100px;
+      padding: 0.3rem 0.7rem;
+      opacity: 0;
+      transform: scale(0.5);
+      transition: opacity 0.3s cubic-bezier(0.34, 1.56, 0.64, 1),
+                  transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+    }
+
+    .demo__item.is-visible {
+      opacity: 1;
+      transform: scale(1);
+    }
+
+    .demo__done-btn {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.72rem;
+      font-weight: 700;
+      color: #fff;
+      background: #22c55e;
+      border-radius: 8px;
+      padding: 0.55rem 1rem;
+      text-align: center;
+      margin-top: 0.75rem;
+      opacity: 0;
+      transform: translateY(6px);
+      transition: opacity 0.3s ease, transform 0.3s ease, scale 0.15s ease;
+    }
+
+    .demo__done-btn.is-visible {
+      opacity: 1;
+      transform: translateY(0);
+    }
+
+    .demo__done-btn.is-pressed {
+      scale: 0.96;
+      filter: brightness(0.85);
+    }
+
+    .demo__sync {
+      display: none;
+      opacity: 0;
+      transition: opacity 0.4s ease;
+      padding: 1.25rem;
+    }
+
+    .demo__sync.is-visible {
+      opacity: 1;
+    }
+
+    .demo__sync-inner {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.6rem;
+    }
+
+    .demo__spinner {
+      width: 16px;
+      height: 16px;
+      border: 2px solid var(--border);
+      border-top-color: var(--purple);
+      border-radius: 50%;
+      animation: demoSpin 0.8s linear infinite;
+    }
+
+    @keyframes demoSpin {
+      to { transform: rotate(360deg); }
+    }
+
+    .demo__sync-text {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.72rem;
+      color: var(--text-dim);
+      letter-spacing: 0.02em;
+    }
+
+    .demo__result {
+      display: none;
+      opacity: 0;
+      transform: translateY(8px);
+      transition: opacity 0.4s ease, transform 0.4s ease;
+      background: var(--surface);
+      border: 1px solid var(--border-accent);
+      border-radius: 12px;
+      padding: 1rem 1.25rem;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .demo__result::before {
+      content: '';
+      position: absolute;
+      top: 0; left: 0; right: 0;
+      height: 1px;
+      background: linear-gradient(90deg, transparent, var(--purple), transparent);
+      opacity: 0.3;
+    }
+
+    .demo__result.is-visible {
+      opacity: 1;
+      transform: translateY(0);
+    }
+
+    .demo__result-text {
+      font-family: 'DM Sans', system-ui, sans-serif;
+      font-size: 0.95rem;
+      color: var(--text);
+      line-height: 1.5;
+      margin-bottom: 0.75rem;
+    }
+
+    .demo__recipe {
+      background: var(--surface-raised);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 0.75rem 1rem;
+    }
+
+    .demo__recipe-title {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.8rem;
+      font-weight: 700;
+      color: var(--text);
+      margin-bottom: 0.3rem;
+    }
+
+    .demo__recipe-meta {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.62rem;
+      color: var(--text-dim);
+      letter-spacing: 0.02em;
+    }
+
+    /* -- description -- */
     .description {
       font-size: 1.05rem;
       line-height: 1.7;
       color: var(--text-dim);
       text-align: center;
-      margin-bottom: 2rem;
+      margin-bottom: 1.25rem;
       max-width: 480px;
     }
 
-    /* ── how it works ── */
+    .description-builder {
+      font-size: 0.9rem;
+      line-height: 1.7;
+      color: var(--text-muted);
+      text-align: center;
+      margin-bottom: 2.5rem;
+      max-width: 480px;
+    }
+
+    .description-builder strong {
+      color: var(--text-dim);
+      font-weight: 500;
+    }
+
+    /* -- section heading -- */
+    .section-heading {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.7rem;
+      font-weight: 700;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: var(--text-muted);
+      margin-bottom: 1rem;
+    }
+
+    /* -- use cases -- */
+    .use-cases {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+      width: 100%;
+      max-width: 480px;
+      margin-bottom: 2.75rem;
+    }
+
+    .use-case {
+      display: flex;
+      align-items: flex-start;
+      gap: 0.85rem;
+      padding: 0.85rem 1rem;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      transition: border-color 0.2s ease;
+      min-height: 4.5rem;
+    }
+
+    .use-case:hover {
+      border-color: var(--border-accent);
+    }
+
+    .use-case__emoji {
+      font-size: 1.4rem;
+      line-height: 1;
+      flex-shrink: 0;
+      margin-top: 0.1rem;
+    }
+
+    .use-case__body {
+      display: flex;
+      flex-direction: column;
+      gap: 0.2rem;
+    }
+
+    .use-case__name {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.75rem;
+      font-weight: 700;
+      color: var(--text);
+      letter-spacing: 0.02em;
+    }
+
+    .use-case__desc {
+      font-family: 'DM Sans', system-ui, sans-serif;
+      font-size: 0.85rem;
+      color: var(--text-dim);
+      line-height: 1.45;
+    }
+
+    /* -- how it works -- */
     .how-it-works {
       display: flex;
       flex-direction: column;
@@ -240,7 +648,7 @@
 
     .step {
       display: flex;
-      align-items: center;
+      align-items: flex-start;
       gap: 0.75rem;
       padding: 0.75rem 0;
       border-bottom: 1px solid var(--border);
@@ -257,6 +665,7 @@
       color: var(--blue-light);
       min-width: 1.5rem;
       text-align: center;
+      line-height: 1.5;
     }
 
     .step-text {
@@ -268,7 +677,7 @@
       line-height: 1.5;
     }
 
-    /* ── features ── */
+    /* -- features -- */
     .features {
       display: grid;
       grid-template-columns: repeat(4, 1fr);
@@ -314,7 +723,7 @@
       line-height: 1.3;
     }
 
-    /* ── links ── */
+    /* -- links -- */
     .links {
       display: flex;
       gap: 0.5rem;
@@ -350,7 +759,7 @@
       flex-shrink: 0;
     }
 
-    /* ── footer ── */
+    /* -- footer -- */
     .footer {
       font-family: 'JetBrains Mono', monospace;
       font-size: 0.65rem;
@@ -368,21 +777,98 @@
       color: var(--blue-light);
     }
 
-    /* ── responsive ── */
+    /* -- launch date -- */
+    .launch-date {
+      text-align: center;
+      margin-bottom: 2.25rem;
+    }
+
+    .launch-date__text {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 1rem;
+      font-weight: 700;
+      color: var(--text-dim);
+      letter-spacing: 0.03em;
+    }
+
+    .launch-date__text span {
+      color: #fff;
+    }
+
+    /* -- tier divider -- */
+    .tier-divider {
+      display: flex;
+      align-items: center;
+      gap: 1.25rem;
+      width: 100%;
+      max-width: 480px;
+      margin: 0.5rem 0 2rem;
+    }
+
+    .tier-divider__line {
+      flex: 1;
+      height: 1px;
+      background: var(--border-accent);
+    }
+
+    .tier-divider__label {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.7rem;
+      font-weight: 700;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: var(--blue-light);
+      white-space: nowrap;
+    }
+
+    /* -- builder pitch -- */
+    .builder-pitch {
+      font-size: 1rem;
+      line-height: 1.7;
+      color: var(--text-dim);
+      text-align: center;
+      margin-bottom: 2rem;
+      max-width: 480px;
+    }
+
+    .builder-pitch strong {
+      color: var(--text);
+      font-weight: 500;
+    }
+
+    /* -- no-dev note -- */
+    .no-dev-note {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.72rem;
+      color: var(--text-muted);
+      text-align: center;
+      margin-bottom: 3rem;
+      letter-spacing: 0.02em;
+    }
+
+    /* -- responsive -- */
     @media (min-width: 640px) {
       .container { padding: 4rem 2rem; }
       .robot-svg { width: 160px; height: 160px; }
       .wordmark { font-size: 4rem; }
       .tagline { font-size: 0.95rem; }
+      .tagline-sub { font-size: 1.3rem; }
+      .launch-date__text { font-size: 1.15rem; }
       .description { font-size: 1.1rem; }
       .feature { padding: 1.5rem 1rem; }
       .feature-label { font-size: 0.7rem; }
+      .demo__viewport { height: 140px; }
+      .demo__bubble-text { font-size: 1.05rem; }
+      .demo__result-text { font-size: 1.05rem; }
     }
 
     @media (max-width: 520px) {
       .features { grid-template-columns: repeat(2, 1fr); }
       .links { flex-direction: column; width: 100%; max-width: 280px; }
       .link { justify-content: center; }
+      .demo__viewport { height: 100px; }
+      .demo__item { font-size: 0.6rem; padding: 0.25rem 0.55rem; }
+      .demo__done-btn { font-size: 0.65rem; padding: 0.45rem 0.8rem; }
     }
   </style>
 </head>
@@ -405,33 +891,150 @@
     <h1 class="wordmark fade-in">ROBO<span class="dot">.</span>APP</h1>
 
     <!-- Tagline -->
-    <p class="tagline fade-in">Native mobile context for AI agents</p>
+    <p class="tagline fade-in">Control your AI Context</p>
+    <p class="tagline-sub fade-in">AI agents need to see the real world. This is how you show them.</p>
 
     <!-- Badge -->
     <div class="badge-wrap fade-in">
       <span class="badge">Claude Code 2026 Hackathon</span>
     </div>
 
-    <!-- Teaser -->
+    <!-- Launch Date -->
+    <div class="launch-date fade-in">
+      <p class="launch-date__text">Launching <span>Monday, February 16</span></p>
+    </div>
+
+    <!-- Consumer description -->
     <p class="description fade-in">
-      Building an AI agent is easy. Getting it phone sensor data? That means months of Swift, Xcode, and App Store review. Robo is the missing bridge — an open-source iOS app that turns your phone's sensors into endpoints any AI agent can use via webhooks, REST API, MCP, or simple email export.
+      AI agents can plan a room layout, suggest dinner, or pick your outfit &mdash; but only if they can see what you see. Robo turns your phone into their eyes. One tap to capture, and it syncs to any agent you choose.
     </p>
 
     <!-- How It Works -->
+    <p class="section-heading fade-in">How It Works</p>
     <div class="how-it-works fade-in">
       <div class="step">
         <span class="step-number">1</span>
-        <span class="step-text">Your agent needs phone data (LiDAR, camera, barcode...)</span>
+        <span class="step-text"><strong>An AI agent requests data</strong> &mdash; "I need a floor plan of your bedroom" or "Show me what's in the fridge." The request appears in your Robo inbox.</span>
       </div>
       <div class="step">
         <span class="step-number">2</span>
-        <span class="step-text">Users download Robo, connect via webhook / REST / email</span>
+        <span class="step-text"><strong>You capture it in one tap</strong> &mdash; Robo activates the right sensor (LiDAR, camera, barcode) and guides you through a clean capture.</span>
       </div>
       <div class="step">
         <span class="step-number">3</span>
-        <span class="step-text">Agent gets structured sensor data — no iOS dev, no App Store</span>
+        <span class="step-text"><strong>It syncs automatically</strong> &mdash; the data goes straight back to the agent. No uploading, no file juggling. You stay in control of what gets shared.</span>
       </div>
     </div>
+
+    <!-- Use Cases -->
+    <p class="section-heading fade-in">Use Cases</p>
+    <div class="use-cases fade-in">
+      <div class="use-case">
+        <span class="use-case__emoji">🛋️</span>
+        <div class="use-case__body">
+          <span class="use-case__name">Room Layout Agent</span>
+          <span class="use-case__desc">LiDAR scan your room. An AI agent plans furniture layouts that actually fit the space.</span>
+        </div>
+      </div>
+      <div class="use-case">
+        <span class="use-case__emoji">🍳</span>
+        <div class="use-case__body">
+          <span class="use-case__name">Meal Planner Agent</span>
+          <span class="use-case__desc">Snap your fridge and pantry. An AI agent suggests meals from what you already have.</span>
+        </div>
+      </div>
+      <div class="use-case">
+        <span class="use-case__emoji">👔</span>
+        <div class="use-case__body">
+          <span class="use-case__name">Outfit Picker Agent</span>
+          <span class="use-case__desc">Photo your closet. An AI agent picks outfits based on weather, your calendar, and what fits.</span>
+        </div>
+      </div>
+      <div class="use-case">
+        <span class="use-case__emoji">🔨</span>
+        <div class="use-case__body">
+          <span class="use-case__name">Home Repair Agent</span>
+          <span class="use-case__desc">Guided multi-photo capture. An AI agent documents the issue and gets you accurate quotes.</span>
+        </div>
+      </div>
+      <div class="use-case">
+        <span class="use-case__emoji">🧸</span>
+        <div class="use-case__body">
+          <span class="use-case__name">Playtime Agent</span>
+          <span class="use-case__desc">Snap the playroom. An AI agent suggests activities based on your kids' ages and what's around.</span>
+        </div>
+      </div>
+      <div class="use-case">
+        <span class="use-case__emoji">🏪</span>
+        <div class="use-case__body">
+          <span class="use-case__name">Store Ops Agent</span>
+          <span class="use-case__desc">Scheduled photo checklists. An AI agent verifies closing duties with timestamps for compliance.</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Demo: animated barcode scan flow (hidden for now) -->
+    <div class="demo fade-in" id="demo" aria-hidden="true" style="display:none">
+      <div class="demo__bubble" id="demo-agent-msg">
+        <div class="demo__agent-row">
+          <div class="demo__agent-icon">
+            <svg viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 2v7c0 1.1.9 2 2 2h4a2 2 0 0 0 2-2V2"/><path d="M7 2v20"/><path d="M21 15V2a5 5 0 0 0-5 5v6c0 1.1.9 2 2 2h3"/><path d="M18 22v-7"/></svg>
+          </div>
+          <span class="demo__agent-name">Practical Chef</span>
+        </div>
+        <p class="demo__bubble-text">"Scan what's in your pantry &mdash; I'll suggest a recipe"</p>
+      </div>
+      <div class="demo__scanner" id="demo-scanner">
+        <div class="demo__viewport">
+          <span class="demo__corner demo__corner--tl"></span>
+          <span class="demo__corner demo__corner--tr"></span>
+          <span class="demo__corner demo__corner--bl"></span>
+          <span class="demo__corner demo__corner--br"></span>
+          <div class="demo__scan-line" id="demo-scan-line"></div>
+          <div class="demo__barcode-overlay" id="demo-barcode">
+            <svg viewBox="0 0 120 50" xmlns="http://www.w3.org/2000/svg">
+              <g fill="#22c55e" opacity="0.5">
+                <rect x="5" y="2" width="2.5" height="34"/><rect x="9" y="2" width="1" height="34"/><rect x="12" y="2" width="2" height="34"/><rect x="16" y="2" width="1" height="34"/><rect x="19" y="2" width="3" height="34"/><rect x="24" y="2" width="1" height="34"/><rect x="27" y="2" width="2" height="34"/><rect x="31" y="2" width="1" height="34"/><rect x="34" y="2" width="2.5" height="34"/><rect x="38" y="2" width="1" height="34"/><rect x="41" y="2" width="3" height="34"/><rect x="46" y="2" width="1" height="34"/><rect x="49" y="2" width="2" height="34"/><rect x="53" y="2" width="1" height="34"/><rect x="56" y="2" width="2.5" height="34"/><rect x="60" y="2" width="1" height="34"/><rect x="63" y="2" width="3" height="34"/><rect x="68" y="2" width="1" height="34"/><rect x="71" y="2" width="2" height="34"/><rect x="75" y="2" width="1" height="34"/><rect x="78" y="2" width="2.5" height="34"/><rect x="82" y="2" width="1" height="34"/><rect x="85" y="2" width="3" height="34"/><rect x="90" y="2" width="1" height="34"/><rect x="93" y="2" width="2" height="34"/><rect x="97" y="2" width="1" height="34"/><rect x="100" y="2" width="2.5" height="34"/><rect x="104" y="2" width="1" height="34"/><rect x="107" y="2" width="3" height="34"/><rect x="112" y="2" width="2" height="34"/>
+              </g>
+              <text x="60" y="44" text-anchor="middle" fill="#22c55e" opacity="0.35" font-family="monospace" font-size="6">4 011200 296908</text>
+            </svg>
+          </div>
+        </div>
+        <div class="demo__items" id="demo-items"></div>
+        <div class="demo__done-btn" id="demo-done-btn">Done &mdash; 3 items scanned</div>
+      </div>
+      <div class="demo__sync" id="demo-sync">
+        <div class="demo__sync-inner">
+          <div class="demo__spinner"></div>
+          <span class="demo__sync-text">Syncing with Practical Chef...</span>
+        </div>
+      </div>
+      <div class="demo__result" id="demo-result">
+        <div class="demo__agent-row">
+          <div class="demo__agent-icon">
+            <svg viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 2v7c0 1.1.9 2 2 2h4a2 2 0 0 0 2-2V2"/><path d="M7 2v20"/><path d="M21 15V2a5 5 0 0 0-5 5v6c0 1.1.9 2 2 2h3"/><path d="M18 22v-7"/></svg>
+          </div>
+          <span class="demo__agent-name">Practical Chef</span>
+        </div>
+        <p class="demo__result-text">You have everything for Thai Coconut Curry!</p>
+        <div class="demo__recipe">
+          <div class="demo__recipe-title">Thai Coconut Chickpea Curry</div>
+          <div class="demo__recipe-meta">25 min &middot; 4 servings &middot; 380 cal</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Tier Divider -->
+    <div class="tier-divider fade-in">
+      <div class="tier-divider__line"></div>
+      <span class="tier-divider__label">For Builders</span>
+      <div class="tier-divider__line"></div>
+    </div>
+
+    <!-- Builder pitch -->
+    <p class="builder-pitch fade-in">
+      Request photos, floor plans, or product scans via <strong>webhooks</strong>, <strong>REST API</strong>, or <strong>MCP</strong>. No iOS development required. Open source &mdash; fork it, extend it, audit the code.
+    </p>
 
     <!-- Features -->
     <div class="features fade-in">
@@ -445,25 +1048,13 @@
         <div class="feature-icon">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><line x1="6" y1="8" x2="6" y2="16"/><line x1="8" y1="8" x2="8" y2="16"/><line x1="11" y1="8" x2="11" y2="16"/><line x1="14" y1="8" x2="14" y2="16"/><line x1="16" y1="8" x2="16" y2="16"/><line x1="18" y1="8" x2="18" y2="16"/></svg>
         </div>
-        <span class="feature-label">Barcode Detection</span>
+        <span class="feature-label">Barcode Scanning</span>
       </div>
       <div class="feature">
         <div class="feature-icon">
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78L12 21.23l8.84-8.84a5.5 5.5 0 0 0 0-7.78z"/></svg>
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18"/><path d="M9 3v18"/><circle cx="6" cy="6" r="0.5" fill="currentColor"/><circle cx="6" cy="15" r="0.5" fill="currentColor"/><circle cx="15" cy="6" r="0.5" fill="currentColor"/><circle cx="15" cy="15" r="0.5" fill="currentColor"/></svg>
         </div>
-        <span class="feature-label">Apple HealthKit</span>
-      </div>
-      <div class="feature">
-        <div class="feature-icon">
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 2l3 5h4l3-5"/><path d="M12 7v10"/><path d="M7 22l3-5h4l3 5"/><circle cx="12" cy="12" r="2"/></svg>
-        </div>
-        <span class="feature-label">BLE Proximity</span>
-      </div>
-      <div class="feature">
-        <div class="feature-icon">
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2a4 4 0 0 1 4 4c0 2-2 3-2 5h-4c0-2-2-3-2-5a4 4 0 0 1 4-4z"/><line x1="10" y1="17" x2="14" y2="17"/><line x1="10" y1="20" x2="14" y2="20"/><line x1="11" y1="23" x2="13" y2="23"/></svg>
-        </div>
-        <span class="feature-label">On-Device ML</span>
+        <span class="feature-label">Guided Photo Tasks</span>
       </div>
       <div class="feature">
         <div class="feature-icon">
@@ -473,9 +1064,21 @@
       </div>
       <div class="feature">
         <div class="feature-icon">
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2a4 4 0 0 1 4 4c0 2-2 3-2 5h-4c0-2-2-3-2-5a4 4 0 0 1 4-4z"/><line x1="10" y1="17" x2="14" y2="17"/><line x1="10" y1="20" x2="14" y2="20"/><line x1="11" y1="23" x2="13" y2="23"/></svg>
         </div>
-        <span class="feature-label">Human-in-the-Loop Inbox</span>
+        <span class="feature-label">On-Device ML</span>
+      </div>
+      <div class="feature">
+        <div class="feature-icon">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7z"/><circle cx="12" cy="12" r="3"/></svg>
+        </div>
+        <span class="feature-label">Agent Connections</span>
+      </div>
+      <div class="feature">
+        <div class="feature-icon">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></svg>
+        </div>
+        <span class="feature-label">Motion Capture</span>
       </div>
       <div class="feature">
         <div class="feature-icon">
@@ -484,6 +1087,9 @@
         <span class="feature-label">Push Notifications</span>
       </div>
     </div>
+
+    <!-- No-dev note -->
+    <p class="no-dev-note fade-in">Not a developer? Just capture and export via email &mdash; no account needed.</p>
 
     <!-- Links -->
     <div class="links fade-in">
@@ -506,5 +1112,108 @@
     <p class="footer fade-in" style="margin-top: 0.5rem;">$85 of Claude API usage. That's it. That's the whole app.</p>
 
   </main>
+<script>
+(function() {
+  var demo = document.getElementById('demo');
+  if (!demo) return;
+
+  var agentMsg = document.getElementById('demo-agent-msg');
+  var scanner = document.getElementById('demo-scanner');
+  var scanLine = document.getElementById('demo-scan-line');
+  var itemsEl = document.getElementById('demo-items');
+  var doneBtn = document.getElementById('demo-done-btn');
+  var syncEl = document.getElementById('demo-sync');
+  var resultEl = document.getElementById('demo-result');
+  var barcodeOverlay = document.getElementById('demo-barcode');
+
+  var timers = [];
+  var playing = false;
+  var ITEMS = ['Chickpeas', 'Coconut Milk', 'Jasmine Rice'];
+
+  function sched(fn, ms) {
+    var id = setTimeout(fn, ms);
+    timers.push(id);
+  }
+
+  function show(el) {
+    el.style.display = 'block';
+    void el.offsetWidth;
+    el.classList.add('is-visible');
+  }
+
+  function resetDemo() {
+    timers.forEach(clearTimeout);
+    timers = [];
+    playing = false;
+    [agentMsg, scanner, syncEl, resultEl].forEach(function(el) {
+      el.classList.remove('is-visible');
+      el.style.display = '';
+    });
+    scanLine.classList.remove('is-scanning');
+    barcodeOverlay.classList.remove('is-visible');
+    doneBtn.classList.remove('is-visible', 'is-pressed');
+    itemsEl.innerHTML = '';
+  }
+
+  function playDemo() {
+    if (playing) return;
+    playing = true;
+
+    sched(function() { show(agentMsg); }, 0);
+    sched(function() { show(scanner); }, 1200);
+    sched(function() { scanLine.classList.add('is-scanning'); }, 1800);
+    sched(function() { barcodeOverlay.classList.add('is-visible'); }, 2200);
+
+    ITEMS.forEach(function(name, i) {
+      sched(function() {
+        var pill = document.createElement('span');
+        pill.className = 'demo__item';
+        pill.textContent = name;
+        itemsEl.appendChild(pill);
+        void pill.offsetWidth;
+        pill.classList.add('is-visible');
+      }, 2800 + i * 1000);
+    });
+
+    sched(function() { scanLine.classList.remove('is-scanning'); barcodeOverlay.classList.remove('is-visible'); }, 5800);
+    sched(function() { doneBtn.classList.add('is-visible'); }, 6200);
+    sched(function() { doneBtn.classList.add('is-pressed'); }, 7200);
+
+    sched(function() {
+      scanner.classList.remove('is-visible');
+      agentMsg.classList.remove('is-visible');
+    }, 7600);
+
+    sched(function() {
+      scanner.style.display = '';
+      agentMsg.style.display = '';
+    }, 8000);
+
+    sched(function() { show(syncEl); }, 8100);
+
+    sched(function() { syncEl.classList.remove('is-visible'); }, 9700);
+    sched(function() { syncEl.style.display = ''; }, 10100);
+
+    sched(function() { show(resultEl); }, 10200);
+
+    sched(function() {
+      resetDemo();
+      sched(playDemo, 1500);
+    }, 14500);
+  }
+
+  var observer = new IntersectionObserver(function(entries) {
+    entries.forEach(function(entry) {
+      if (entry.isIntersecting) {
+        if (!playing) playDemo();
+      } else {
+        resetDemo();
+      }
+    });
+  }, { threshold: 0.3 });
+
+  observer.observe(demo);
+})();
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Restructure landing page into two clear audience tiers: **consumers** (AI maxers who want to use agents) at top, **builders** (developers who care about API/webhooks/MCP) below a visual divider
- Rewrite all copy to clearly convey **AI agents**, not human professionals — renamed use cases to "Room Layout Agent", "Meal Planner Agent", etc.
- New tagline: "Control your AI Context" with sub-tagline "AI agents need to see the real world. This is how you show them."
- Add "Launching Monday, February 16" prominent date
- Equalize use case card heights for cleaner visual appearance
- Hide demo animation (too complex for current messaging)
- Update OG/Twitter meta tags to match new messaging

## Test plan
- [ ] Load https://robo.app after deploy and verify two-tier structure
- [ ] Check OG tags render correctly (paste URL in Discord/Slack/iMessage)
- [ ] Verify responsive layout on mobile (cards, tier divider, launch date)
- [ ] Confirm demo section is hidden but code preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)