### PR TITLE
feat: Chef agent — barcode scan + multi-photo capture

### DIFF
--- a/docs/plans/2026-02-12-feat-chef-agent-barcode-multi-photo-capture-plan.md
+++ b/docs/plans/2026-02-12-feat-chef-agent-barcode-multi-photo-capture-plan.md
@@ -1,0 +1,465 @@
+---
+title: "Agent Demo: Chef — barcode scan + multi-photo capture for CPG products"
+type: feat
+date: 2026-02-12
+issue: "#95"
+deadline: 2026-02-16 3:00 PM EST
+---
+
+# Agent Demo: Chef — Barcode Scan + Multi-Photo Capture
+
+## Overview
+
+Add a **Chef agent demo** that asks the user to scan a CPG product from their kitchen. Demonstrates a compound capture flow: optional barcode scan → multi-photo capture (front of package, nutrition label) → task completion. This is the first multi-step capture flow in the app and showcases native iOS sensor composition.
+
+**Why this matters for the demo:** Multi-photo capture is a key differentiator. Combined with optional barcode scanning, it shows how Robo makes complex, multi-sensor data capture trivial for AI agents.
+
+## Problem Statement
+
+Current agent requests map 1:1 to a single sensor (barcode OR camera OR LiDAR). Real-world agent tasks often need **multiple data types in sequence**. Additionally, photos from `PhotoCaptureView` are **not persisted** — they vanish on dismiss. The history view cannot show captured photos, and products without barcodes have no storage model.
+
+## Proposed Solution
+
+### Architecture: Compound Capture Flow
+
+Create a new `ProductScanFlowView` that orchestrates a multi-phase capture within a single `.fullScreenCover`:
+
+```
+AgentsView → .fullScreenCover(ProductScanFlowView)
+                 ├── Phase 1: Barcode scan (skippable)
+                 ├── Phase 2: Multi-photo capture (1-3 photos)
+                 ├── Phase 3: Review & confirm
+                 └── Phase 4: Save + dismiss → sync animation
+```
+
+### New SkillType: `.productScan`
+
+Add a compound skill type to `AgentRequest.SkillType` so the dispatch switch in `AgentsView.handleScanNow()` routes to the new flow view.
+
+### New Data Model: V6 Schema
+
+A new `ProductCaptureRecord` in SwiftData (schema V6) that:
+- Optionally references a barcode (`barcodeValue: String?`)
+- Stores photo file paths (`photoFileNames: [String]` — persisted as JSON string)
+- Links to the originating agent (`agentId`, `agentName`)
+- Stores basic metadata (timestamp, request ID, photo count)
+
+Photos saved as JPEG files in Application Support directory (persists across launches, not backed up to iCloud).
+
+## Technical Approach
+
+### Phase 1: Data Model (V6 Schema + Photo Persistence)
+
+**File: `ios/Robo/Models/RoboSchema.swift`**
+
+Add `RoboSchemaV6` with new `ProductCaptureRecord` model:
+
+```swift
+// New V6 schema
+enum RoboSchemaV6: VersionedSchema {
+    static var versionIdentifier = Schema.Version(6, 0, 0)
+    static var models: [any PersistentModel.Type] {
+        [ScanRecord.self, RoomScanRecord.self, MotionRecord.self,
+         AgentCompletionRecord.self, ProductCaptureRecord.self]
+    }
+
+    @Model
+    final class ProductCaptureRecord {
+        var id: UUID
+        var barcodeValue: String?       // nil if user skipped barcode
+        var symbology: String?          // barcode symbology if scanned
+        var photoFileNames: String      // JSON array of filenames
+        var photoCount: Int
+        var capturedAt: Date
+        var agentId: String?
+        var agentName: String?
+        var requestId: String?
+        // Nutrition fields (populated async via barcode lookup)
+        var foodName: String?
+        var brandName: String?
+        var calories: Double?
+        var photoThumbURL: String?      // from Nutritionix API
+        var nutritionLookedUp: Bool
+
+        init(barcodeValue: String? = nil, symbology: String? = nil,
+             photoFileNames: [String], agentId: String? = nil,
+             agentName: String? = nil, requestId: String? = nil) {
+            self.id = UUID()
+            self.barcodeValue = barcodeValue
+            self.symbology = symbology
+            self.photoFileNames = // encode as JSON
+            self.photoCount = photoFileNames.count
+            self.capturedAt = Date()
+            self.agentId = agentId
+            self.agentName = agentName
+            self.requestId = requestId
+            self.nutritionLookedUp = false
+        }
+    }
+}
+
+// Update migration plan: V1 → V2 → V3 → V4 → V5 → V6
+// Update typealias: typealias ProductCaptureRecord = RoboSchemaV6.ProductCaptureRecord
+// Update RoboApp.swift ModelContainer to reference V6
+```
+
+**File: NEW `ios/Robo/Services/PhotoStorageService.swift`**
+
+Handles JPEG file persistence and thumbnail generation:
+
+```swift
+enum PhotoStorageService {
+    static let photosDir = "ProductPhotos"
+    static let thumbsDir = "ProductThumbs"
+    static let thumbWidth: CGFloat = 400  // 2x for retina
+
+    /// Save full-res JPEG, return filename
+    static func save(_ image: UIImage) -> String?
+
+    /// Generate and save thumbnail, return thumbnail filename
+    static func saveThumbnail(_ image: UIImage, filename: String) -> String?
+
+    /// Load image from filename
+    static func load(_ filename: String) -> UIImage?
+
+    /// Load thumbnail from filename
+    static func loadThumbnail(_ filename: String) -> UIImage?
+
+    /// Delete photos by filenames
+    static func delete(_ filenames: [String])
+}
+```
+
+- Storage location: `Application Support/ProductPhotos/` (full-res) and `Application Support/ProductThumbs/` (thumbnails)
+- Naming: `{UUID}.jpg` for uniqueness
+- Save photos immediately on capture (JPEG write is fast, prevents data loss on interruption)
+- Generate 400px-wide thumbnail at save time (prevents scroll jank in history)
+
+### Phase 2: Compound Flow View
+
+**File: NEW `ios/Robo/Views/ProductScanFlowView.swift`**
+
+Single view managing all phases via internal state machine:
+
+```swift
+struct ProductScanFlowView: View {
+    let captureContext: CaptureContext?
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.modelContext) private var modelContext
+
+    enum FlowPhase {
+        case barcodeScan    // Phase 1: scan or skip
+        case photoCapture   // Phase 2: take photos
+        case review         // Phase 3: review all data
+    }
+
+    @State private var phase: FlowPhase = .barcodeScan
+    @State private var scannedBarcode: String?        // nil if skipped
+    @State private var scannedSymbology: String?
+    @State private var capturedPhotos: [(UIImage, String)] = []  // (image, filename)
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                switch phase {
+                case .barcodeScan:
+                    BarcodeScanPhaseView(
+                        onScanned: { code, symbology in
+                            scannedBarcode = code
+                            scannedSymbology = symbology
+                            phase = .photoCapture
+                        },
+                        onSkip: { phase = .photoCapture }
+                    )
+                case .photoCapture:
+                    PhotoCapturePhaseView(
+                        capturedPhotos: $capturedPhotos,
+                        onDone: { phase = .review }
+                    )
+                case .review:
+                    ProductReviewView(
+                        barcode: scannedBarcode,
+                        photos: capturedPhotos,
+                        onConfirm: { saveAndDismiss() },
+                        onRetakePhotos: { phase = .photoCapture }
+                    )
+                }
+            }
+        }
+    }
+
+    private func saveAndDismiss() {
+        let filenames = capturedPhotos.map { $0.1 }
+        let record = ProductCaptureRecord(
+            barcodeValue: scannedBarcode,
+            symbology: scannedSymbology,
+            photoFileNames: filenames,
+            agentId: captureContext?.agentId,
+            agentName: captureContext?.agentName,
+            requestId: captureContext?.requestId.uuidString
+        )
+        modelContext.insert(record)
+        try? modelContext.save()  // Explicit save before dismiss
+
+        // Fire-and-forget nutrition lookup if barcode was scanned
+        if let upc = scannedBarcode {
+            Task { await NutritionService.lookupForProduct(upc: upc, record: record, ...) }
+        }
+
+        dismiss()
+    }
+}
+```
+
+**Key design decisions:**
+- **Single `.fullScreenCover`** — no chaining of covers (avoids SwiftUI animation glitches)
+- **No back-navigation from photos to barcode** — user must cancel and restart (hackathon simplicity)
+- **Photos saved to disk immediately on capture** via `PhotoStorageService` — resilient to interruption
+- **SwiftData record created only on final "Done"** — no orphaned records on cancellation
+
+### Phase 3: Barcode Scan Phase (Modified)
+
+**File: `ios/Robo/Views/ProductScanFlowView.swift` (subview)**
+
+A simplified barcode scanner subview (reuses the VisionKit DataScanner) with key differences from standalone `BarcodeScannerView`:
+
+- **Single-scan mode**: Stops scanning after first successful detection (not continuous)
+- **Prominent "Skip" button**: Large, visible at bottom — "No barcode? Skip →"
+- **Confirmation toast**: Shows scanned code with brief pause before auto-advancing to photos
+- **Does NOT create a ScanRecord** — the barcode value is passed to the flow coordinator, not persisted independently
+- Falls back to "Camera not available" UI on simulator
+
+### Phase 4: Photo Capture Phase (Modified)
+
+Adapts existing `PhotoCaptureView` patterns with modifications:
+
+- **Checklist guidance**: "Front of package", "Nutrition label" (soft suggestions, not enforced)
+- **1-3 photo recommendation**: Subtitle text, not a hard limit
+- **Photos saved to disk on capture**: Each shutter press → JPEG write via `PhotoStorageService`
+- **Thumbnail strip**: Shows saved photos at bottom of capture screen
+- **"Done" requires at least 1 photo**: If 0 photos, show confirmation: "No photos taken. Go back?"
+- **Camera permission check**: Mirror `BarcodeScannerView`'s `ContentUnavailableView` pattern for denied/unavailable states
+
+### Phase 5: Review Screen
+
+New view showing summary before final save:
+
+- Product image (first photo, large)
+- Barcode value if scanned (or "No barcode" label)
+- Photo grid (all captured photos as thumbnails)
+- "Retake Photos" button → goes back to photo phase
+- "Done" button → saves record + dismisses flow
+- Clear, satisfying completion state
+
+### Phase 6: Agent Wiring
+
+**File: `ios/Robo/Models/AgentConnection.swift`**
+
+Add `.productScan` to `SkillType`:
+
+```swift
+enum SkillType {
+    case lidar
+    case barcode
+    case camera
+    case motion
+    case productScan  // NEW: compound barcode + photos
+}
+```
+
+**File: `ios/Robo/Services/MockAgentService.swift`**
+
+Update the existing "Practical Chef" agent (line 23-32) with a pending request:
+
+```swift
+AgentConnection(
+    id: UUID(uuidString: "00000000-0000-0000-0000-000000000002")!,
+    name: "Practical Chef",
+    description: "Analyzes ingredients and nutrition for meal planning",
+    iconName: "fork.knife",
+    accentColor: .orange,
+    status: .connected,
+    lastSyncDate: nil,  // No prior sync
+    pendingRequest: AgentRequest(
+        id: UUID(),
+        title: "Scan a product from your kitchen",
+        description: "I'd love to analyze a product's ingredients and nutrition. Scan the barcode and snap a few photos of the package.",
+        skillType: .productScan,
+        photoChecklist: [
+            PhotoTask(id: UUID(), label: "Front of package", isCompleted: false),
+            PhotoTask(id: UUID(), label: "Nutrition label", isCompleted: false),
+        ],
+        roomNameHint: nil
+    )
+)
+```
+
+**File: `ios/Robo/Views/AgentsView.swift`**
+
+Add case to `handleScanNow`:
+
+```swift
+case .productScan: showingProductScan = true
+```
+
+Add new state and `.fullScreenCover`:
+
+```swift
+@State private var showingProductScan = false
+
+.fullScreenCover(isPresented: $showingProductScan) {
+    ProductScanFlowView(captureContext: selectedCaptureContext)
+}
+```
+
+Update dismiss handler to detect new `ProductCaptureRecord` entries (same pattern as barcode/LiDAR detection).
+
+### Phase 7: History View Updates
+
+**File: `ios/Robo/Views/ScanHistoryView.swift`**
+
+In "By Agent" mode, add `ProductCaptureRecord` query and display:
+
+```swift
+@Query(sort: \ProductCaptureRecord.capturedAt, order: .reverse)
+private var productCaptures: [ProductCaptureRecord]
+```
+
+Product capture rows show:
+- First photo as thumbnail (loaded from `PhotoStorageService.loadThumbnail`)
+- Product name (from nutrition lookup) or "Product (date)" fallback
+- Barcode value if present, photo count badge
+- Tap → new `ProductDetailView`
+
+**File: NEW `ios/Robo/Views/ProductDetailView.swift`**
+
+Detail view for a product capture:
+- Photo gallery (scrollable, tap to view full-res)
+- Barcode section (if present) with nutrition data
+- Agent attribution ("Captured for Practical Chef")
+- Timestamp, delete action
+
+### ERD: Data Model Changes
+
+```mermaid
+erDiagram
+    ProductCaptureRecord {
+        UUID id PK
+        String barcodeValue "nullable - skipped barcode"
+        String symbology "nullable"
+        String photoFileNames "JSON array of filenames"
+        Int photoCount
+        Date capturedAt
+        String agentId "nullable"
+        String agentName "nullable"
+        String requestId "nullable"
+        String foodName "nullable - from nutrition API"
+        String brandName "nullable"
+        Double calories "nullable"
+        String photoThumbURL "nullable - from Nutritionix"
+        Bool nutritionLookedUp
+    }
+
+    ScanRecord {
+        UUID id PK
+        String barcodeValue
+        String symbology
+        Date capturedAt
+        String agentId "nullable"
+        String agentName "nullable"
+    }
+
+    AgentCompletionRecord {
+        UUID id PK
+        String agentId
+        String skillType
+        Int itemCount
+        Date completedAt
+    }
+
+    ProductCaptureRecord ||--o{ PhotoFile : "stores on disk"
+    ProductCaptureRecord }o--|| AgentConnection : "captured for"
+```
+
+## Implementation Sequence
+
+### Step 1: Data Model (V6 Schema) + Photo Storage
+- [x] Add `RoboSchemaV6` with `ProductCaptureRecord`
+- [x] Add V5→V6 lightweight migration
+- [x] Update `RoboApp.swift` ModelContainer
+- [x] Create `PhotoStorageService`
+- **Files:** `RoboSchema.swift`, `RoboApp.swift`, NEW `PhotoStorageService.swift`
+
+### Step 2: Compound Flow View
+- [x] Create `ProductScanFlowView` with phase state machine
+- [x] Barcode scan phase (single-scan mode, skip button)
+- [x] Photo capture phase (save to disk on capture, checklist guidance)
+- [x] Review phase (photo grid, confirm/retake)
+- **Files:** NEW `ProductScanFlowView.swift`
+
+### Step 3: Agent Wiring
+- [x] Add `.productScan` to `SkillType`
+- [x] Update Chef agent mock data with pending request
+- [x] Add dispatch case in `AgentsView.handleScanNow`
+- [x] Add `.fullScreenCover` and dismiss handler
+- **Files:** `AgentConnection.swift`, `MockAgentService.swift`, `AgentsView.swift`
+
+### Step 4: History View Updates
+- [x] Add `ProductCaptureRecord` query to `ScanHistoryView`
+- [x] Product rows with photo thumbnails
+- [x] Create `ProductDetailView` for full detail
+- **Files:** `ScanHistoryView.swift`, NEW `ProductDetailView.swift`
+
+### Step 5: Polish & Demo Prep
+- [x] Camera permission check in photo phase
+- [ ] Verify nutrition lookup works for demo product
+- [ ] Test full flow on physical device
+- [ ] Time the demo flow (target: under 3 minutes)
+
+## Edge Cases & Decisions
+
+| Scenario | Decision |
+|---|---|
+| User takes 0 photos and taps Done | Show confirmation "No photos taken. Go back?" — don't complete task |
+| User scans wrong barcode | No back-navigation for MVP; cancel and restart |
+| Camera permission denied | Show `ContentUnavailableView` with settings link |
+| Nutrition API down | Fire-and-forget; product shows as "Product (date)" in history |
+| Multiple barcodes in frame | Single-scan mode stops after first detection |
+| App killed mid-flow | Photos already on disk survive; SwiftData record not created (no orphan records). Flow restarts from beginning |
+| Product without barcode in history | Shows first photo as identifier, "No barcode" label |
+| Storage full | JPEG write fails silently; photo not added to array. User sees fewer photos than expected |
+
+## Demo Rehearsal Checklist
+
+- [ ] Pre-scan demo product barcode to verify Nutritionix returns data for that UPC
+- [ ] Physical iPhone charged, camera lens clean
+- [ ] Test on actual demo network for latency
+- [ ] Time complete flow end-to-end (target < 2 min for capture, 1 min for showing result)
+- [ ] Have a known-good product ready (something with clear barcode + nutrition label)
+- [ ] Fallback plan: if nutrition API is slow, the flow still completes — photos and barcode are stored
+
+## Files Summary
+
+| File | Action | Description |
+|---|---|---|
+| `ios/Robo/Models/RoboSchema.swift` | Edit | Add V6 schema with `ProductCaptureRecord` |
+| `ios/Robo/RoboApp.swift` | Edit | Update ModelContainer to V6 |
+| `ios/Robo/Services/PhotoStorageService.swift` | **Create** | JPEG persistence + thumbnail generation |
+| `ios/Robo/Views/ProductScanFlowView.swift` | **Create** | Compound barcode→photos→review flow |
+| `ios/Robo/Models/AgentConnection.swift` | Edit | Add `.productScan` SkillType |
+| `ios/Robo/Services/MockAgentService.swift` | Edit | Chef agent pending request |
+| `ios/Robo/Views/AgentsView.swift` | Edit | Dispatch + dismiss handler for productScan |
+| `ios/Robo/Views/ScanHistoryView.swift` | Edit | Show ProductCaptureRecord rows with thumbnails |
+| `ios/Robo/Views/ProductDetailView.swift` | **Create** | Product detail with photo gallery |
+| `ios/Robo/Services/AgentStore.swift` | Edit | (if needed) Ensure Chef resolves correctly |
+
+## References
+
+- Issue: #95
+- Existing barcode scanner: `ios/Robo/Views/BarcodeScannerView.swift`
+- Existing photo capture: `ios/Robo/Views/PhotoCaptureView.swift`
+- Schema history: `ios/Robo/Models/RoboSchema.swift` (V1→V5)
+- Nutrition lookup: `ios/Robo/Services/NutritionService.swift`
+- Agent dispatch: `ios/Robo/Views/AgentsView.swift:119-138`
+- Learnings: `docs/solutions/architecture-issues/swiftdata-schema-drift-agent-context-threading-20260212.md`
+- Learnings: `docs/solutions/database-issues/swiftdata-persistence-failure-no-save-no-schema-versioning-20260210.md`

--- a/ios/Robo/Models/AgentConnection.swift
+++ b/ios/Robo/Models/AgentConnection.swift
@@ -31,6 +31,7 @@ struct AgentRequest: Identifiable {
         case barcode
         case camera
         case motion
+        case productScan
     }
 
     init(

--- a/ios/Robo/RoboApp.swift
+++ b/ios/Robo/RoboApp.swift
@@ -22,7 +22,7 @@ struct RoboApp: App {
     /// Attempts to create a ModelContainer with migration, falling back to a
     /// backup-and-recreate strategy. NEVER deletes the store without backing up first.
     private static func createResilientContainer() -> ModelContainer {
-        let schema = Schema(versionedSchema: RoboSchemaV5.self)
+        let schema = Schema(versionedSchema: RoboSchemaV6.self)
         let config = ModelConfiguration(schema: schema)
 
         // Attempt 1: Normal migration

--- a/ios/Robo/Services/MockAgentService.swift
+++ b/ios/Robo/Services/MockAgentService.swift
@@ -23,12 +23,21 @@ enum MockAgentService {
             AgentConnection(
                 id: UUID(uuidString: "00000000-0000-0000-0000-000000000002")!,
                 name: "Practical Chef",
-                description: "Recipe suggestions from what's in your kitchen",
+                description: "Analyzes ingredients and nutrition for meal planning",
                 iconSystemName: "fork.knife",
                 accentColor: .orange,
                 status: .connected,
-                lastSyncDate: Calendar.current.date(byAdding: .hour, value: -2, to: Date()),
-                pendingRequest: nil
+                lastSyncDate: nil,
+                pendingRequest: AgentRequest(
+                    id: UUID(uuidString: "00000000-0000-0000-0000-000000000020")!,
+                    title: "Scan a product from your kitchen",
+                    description: "Scan the barcode and snap a few photos of the package — I'll analyze the ingredients and nutrition.",
+                    skillType: .productScan,
+                    photoChecklist: [
+                        PhotoTask(id: UUID(), label: "Front of package", isCompleted: false),
+                        PhotoTask(id: UUID(), label: "Nutrition label", isCompleted: false)
+                    ]
+                )
             ),
             AgentConnection(
                 id: UUID(uuidString: "00000000-0000-0000-0000-000000000003")!,

--- a/ios/Robo/Services/NutritionService.swift
+++ b/ios/Robo/Services/NutritionService.swift
@@ -53,4 +53,40 @@ enum NutritionService {
             try? modelContext.save()
         }
     }
+
+    /// Lookup nutrition for a ProductCaptureRecord (used by Chef agent flow).
+    @MainActor
+    static func lookupForProduct(
+        upc: String,
+        record: ProductCaptureRecord,
+        apiService: APIService,
+        modelContext: ModelContext
+    ) async {
+        guard !record.nutritionLookedUp else { return }
+
+        do {
+            let response = try await apiService.lookupNutrition(upc: upc)
+
+            record.nutritionLookedUp = true
+
+            guard response.found else {
+                try? modelContext.save()
+                return
+            }
+
+            record.foodName = response.foodName
+            record.brandName = response.brandName
+            record.calories = response.calories
+            record.photoThumbURL = response.photoThumb
+
+            try? modelContext.save()
+
+            if let thumb = response.photoThumb {
+                await ImageCacheService.prefetch(urlString: thumb)
+            }
+        } catch {
+            record.nutritionLookedUp = true
+            try? modelContext.save()
+        }
+    }
 }

--- a/ios/Robo/Services/PhotoStorageService.swift
+++ b/ios/Robo/Services/PhotoStorageService.swift
@@ -1,0 +1,106 @@
+import UIKit
+
+enum PhotoStorageService {
+    private static let photosDir = "ProductPhotos"
+    private static let thumbsDir = "ProductThumbs"
+    private static let thumbMaxDimension: CGFloat = 400
+    private static let jpegQuality: CGFloat = 0.8
+
+    // MARK: - Save
+
+    /// Save full-res JPEG to disk, returns filename (UUID.jpg) or nil on failure.
+    static func save(_ image: UIImage) -> String? {
+        guard let data = image.jpegData(compressionQuality: jpegQuality) else { return nil }
+        let filename = "\(UUID().uuidString).jpg"
+
+        guard let dir = photosDirectory() else { return nil }
+        let url = dir.appendingPathComponent(filename)
+
+        do {
+            try data.write(to: url, options: .atomic)
+        } catch {
+            return nil
+        }
+
+        // Generate thumbnail alongside
+        saveThumbnail(image, filename: filename)
+        return filename
+    }
+
+    /// Generate and save a thumbnail.
+    @discardableResult
+    static func saveThumbnail(_ image: UIImage, filename: String) -> Bool {
+        guard let dir = thumbsDirectory() else { return false }
+
+        let scale = min(thumbMaxDimension / image.size.width, thumbMaxDimension / image.size.height, 1.0)
+        let size = CGSize(width: image.size.width * scale, height: image.size.height * scale)
+
+        let renderer = UIGraphicsImageRenderer(size: size)
+        let thumb = renderer.image { _ in
+            image.draw(in: CGRect(origin: .zero, size: size))
+        }
+
+        guard let data = thumb.jpegData(compressionQuality: 0.7) else { return false }
+        let url = dir.appendingPathComponent(filename)
+
+        do {
+            try data.write(to: url, options: .atomic)
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    // MARK: - Load
+
+    static func load(_ filename: String) -> UIImage? {
+        guard let dir = photosDirectory() else { return nil }
+        let url = dir.appendingPathComponent(filename)
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return UIImage(data: data)
+    }
+
+    static func loadThumbnail(_ filename: String) -> UIImage? {
+        guard let dir = thumbsDirectory() else { return nil }
+        let url = dir.appendingPathComponent(filename)
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return UIImage(data: data)
+    }
+
+    // MARK: - Delete
+
+    static func delete(_ filenames: [String]) {
+        let fm = FileManager.default
+        if let photoDir = photosDirectory() {
+            for name in filenames {
+                try? fm.removeItem(at: photoDir.appendingPathComponent(name))
+            }
+        }
+        if let thumbDir = thumbsDirectory() {
+            for name in filenames {
+                try? fm.removeItem(at: thumbDir.appendingPathComponent(name))
+            }
+        }
+    }
+
+    // MARK: - Directories
+
+    private static func photosDirectory() -> URL? {
+        ensureDirectory(named: photosDir)
+    }
+
+    private static func thumbsDirectory() -> URL? {
+        ensureDirectory(named: thumbsDir)
+    }
+
+    private static func ensureDirectory(named name: String) -> URL? {
+        guard let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
+            return nil
+        }
+        let dir = appSupport.appendingPathComponent(name)
+        if !FileManager.default.fileExists(atPath: dir.path) {
+            try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        }
+        return dir
+    }
+}

--- a/ios/Robo/Views/ProductDetailView.swift
+++ b/ios/Robo/Views/ProductDetailView.swift
@@ -1,0 +1,176 @@
+import SwiftUI
+import SwiftData
+
+struct ProductDetailView: View {
+    let product: ProductCaptureRecord
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.dismiss) private var dismiss
+    @State private var photos: [UIImage] = []
+    @State private var selectedPhotoIndex: Int?
+
+    var body: some View {
+        List {
+            // Photo gallery
+            Section {
+                if photos.isEmpty {
+                    HStack {
+                        Spacer()
+                        ProgressView()
+                        Spacer()
+                    }
+                    .padding(.vertical, 20)
+                } else {
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: 8) {
+                            ForEach(Array(photos.enumerated()), id: \.offset) { index, photo in
+                                Image(uiImage: photo)
+                                    .resizable()
+                                    .scaledToFill()
+                                    .frame(width: 200, height: 260)
+                                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                                    .onTapGesture {
+                                        selectedPhotoIndex = index
+                                    }
+                            }
+                        }
+                        .padding(.horizontal, 4)
+                    }
+                    .listRowInsets(EdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 8))
+                }
+            } header: {
+                Text("\(product.photoCount) Photo\(product.photoCount == 1 ? "" : "s")")
+            }
+
+            // Product info
+            Section("Product") {
+                if let name = product.foodName {
+                    HStack {
+                        Text("Name")
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Text(name)
+                    }
+                }
+                if let brand = product.brandName {
+                    HStack {
+                        Text("Brand")
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Text(brand)
+                    }
+                }
+                if let cal = product.calories {
+                    HStack {
+                        Text("Calories")
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Text("\(Int(cal))")
+                    }
+                }
+            }
+
+            // Barcode info
+            Section("Barcode") {
+                if let barcode = product.barcodeValue {
+                    HStack {
+                        Text("Value")
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Text(barcode)
+                            .font(.subheadline.monospaced())
+                            .textSelection(.enabled)
+                    }
+                    if let symbology = product.symbology {
+                        HStack {
+                            Text("Type")
+                                .foregroundStyle(.secondary)
+                            Spacer()
+                            Text(symbology.replacingOccurrences(of: "VNBarcodeSymbology", with: ""))
+                        }
+                    }
+                } else {
+                    Text("No barcode scanned")
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            // Metadata
+            Section("Details") {
+                HStack {
+                    Text("Captured")
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Text(product.capturedAt, style: .date)
+                    Text(product.capturedAt, style: .time)
+                }
+                if let agentName = product.agentName {
+                    HStack {
+                        Text("Agent")
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Text(agentName)
+                    }
+                }
+            }
+
+            // Delete
+            Section {
+                Button("Delete Product", role: .destructive) {
+                    PhotoStorageService.delete(product.photoFileNames)
+                    modelContext.delete(product)
+                    try? modelContext.save()
+                    dismiss()
+                }
+            }
+        }
+        .navigationTitle(product.foodName ?? "Product")
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            loadPhotos()
+        }
+        .fullScreenCover(item: Binding(
+            get: { selectedPhotoIndex.map { IdentifiableIndex(index: $0) } },
+            set: { selectedPhotoIndex = $0?.index }
+        )) { item in
+            PhotoFullScreenView(image: photos[item.index], onDismiss: { selectedPhotoIndex = nil })
+        }
+    }
+
+    private func loadPhotos() {
+        photos = product.photoFileNames.compactMap { PhotoStorageService.load($0) }
+    }
+}
+
+// MARK: - Helpers
+
+private struct IdentifiableIndex: Identifiable {
+    let index: Int
+    var id: Int { index }
+}
+
+private struct PhotoFullScreenView: View {
+    let image: UIImage
+    let onDismiss: () -> Void
+
+    var body: some View {
+        ZStack {
+            Color.black.ignoresSafeArea()
+            Image(uiImage: image)
+                .resizable()
+                .scaledToFit()
+        }
+        .onTapGesture {
+            onDismiss()
+        }
+        .overlay(alignment: .topTrailing) {
+            Button {
+                onDismiss()
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.title)
+                    .foregroundStyle(.white.opacity(0.8))
+                    .padding()
+            }
+        }
+    }
+}

--- a/ios/Robo/Views/ProductScanFlowView.swift
+++ b/ios/Robo/Views/ProductScanFlowView.swift
@@ -1,0 +1,578 @@
+import SwiftUI
+import VisionKit
+import AVFoundation
+import AudioToolbox
+import SwiftData
+
+struct ProductScanFlowView: View {
+    var captureContext: CaptureContext? = nil
+
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.modelContext) private var modelContext
+    @Environment(APIService.self) private var apiService
+
+    enum FlowPhase {
+        case barcodeScan
+        case photoCapture
+        case review
+    }
+
+    @State private var phase: FlowPhase = .barcodeScan
+    @State private var scannedBarcode: String?
+    @State private var scannedSymbology: String?
+    @State private var capturedPhotos: [(image: UIImage, filename: String)] = []
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                switch phase {
+                case .barcodeScan:
+                    barcodeScanPhase
+                case .photoCapture:
+                    photoCapturePhase
+                case .review:
+                    reviewPhase
+                }
+            }
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        cleanupAndDismiss()
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Phase 1: Barcode Scan
+
+    private var barcodeScanPhase: some View {
+        ZStack {
+            if DataScannerViewController.isSupported {
+                if DataScannerViewController.isAvailable {
+                    SingleScanRepresentable(onScanned: handleBarcodeScan)
+                        .ignoresSafeArea()
+                } else {
+                    ContentUnavailableView {
+                        Label("Camera Access Required", systemImage: "camera.fill")
+                    } description: {
+                        Text("Robo needs camera access to scan barcodes.")
+                    } actions: {
+                        Button("Open Settings") {
+                            if let url = URL(string: UIApplication.openSettingsURLString) {
+                                UIApplication.shared.open(url)
+                            }
+                        }
+                    }
+                }
+            } else {
+                ContentUnavailableView(
+                    "Scanner Not Available",
+                    systemImage: "barcode.viewfinder",
+                    description: Text("This device does not support barcode scanning.")
+                )
+            }
+
+            // Overlay: scanned toast or skip button
+            VStack {
+                Spacer()
+
+                if let code = scannedBarcode {
+                    // Show scanned code briefly before auto-advancing
+                    HStack(spacing: 12) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(.green)
+                        Text(code)
+                            .font(.subheadline.monospaced())
+                    }
+                    .padding()
+                    .background(.ultraThinMaterial)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                    .padding(.bottom, 8)
+                } else {
+                    Button {
+                        withAnimation { phase = .photoCapture }
+                    } label: {
+                        HStack(spacing: 8) {
+                            Text("No barcode? Skip")
+                            Image(systemName: "arrow.right")
+                        }
+                        .font(.headline)
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 24)
+                        .padding(.vertical, 14)
+                        .background(.ultraThinMaterial)
+                        .clipShape(Capsule())
+                    }
+                    .padding(.bottom, 24)
+                }
+            }
+        }
+        .navigationTitle("Scan Barcode")
+    }
+
+    private func handleBarcodeScan(_ code: String, _ symbology: String) {
+        // Single-scan: only accept first barcode
+        guard scannedBarcode == nil else { return }
+
+        scannedBarcode = code
+        scannedSymbology = symbology
+
+        // Haptic + sound
+        let generator = UINotificationFeedbackGenerator()
+        generator.notificationOccurred(.success)
+        AudioServicesPlaySystemSound(1057)
+
+        // Brief pause then advance to photos
+        Task {
+            try? await Task.sleep(for: .milliseconds(800))
+            withAnimation { phase = .photoCapture }
+        }
+    }
+
+    // MARK: - Phase 2: Photo Capture
+
+    private var photoCapturePhase: some View {
+        ProductPhotoCaptureView(
+            capturedPhotos: $capturedPhotos,
+            onDone: {
+                if capturedPhotos.isEmpty {
+                    // Stay in capture — user needs at least 1 photo
+                } else {
+                    withAnimation { phase = .review }
+                }
+            }
+        )
+    }
+
+    // MARK: - Phase 3: Review
+
+    private var reviewPhase: some View {
+        VStack(spacing: 0) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    // Barcode section
+                    if let code = scannedBarcode {
+                        HStack(spacing: 12) {
+                            Image(systemName: "barcode.viewfinder")
+                                .font(.title2)
+                                .foregroundStyle(.orange)
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text("Barcode")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                Text(code)
+                                    .font(.subheadline.monospaced())
+                            }
+                        }
+                        .padding()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(.secondary.opacity(0.1))
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                    } else {
+                        HStack(spacing: 12) {
+                            Image(systemName: "barcode.viewfinder")
+                                .font(.title2)
+                                .foregroundStyle(.secondary)
+                            Text("No barcode scanned")
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                        }
+                        .padding()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(.secondary.opacity(0.05))
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                    }
+
+                    // Photo grid
+                    Text("\(capturedPhotos.count) photo\(capturedPhotos.count == 1 ? "" : "s")")
+                        .font(.headline)
+
+                    LazyVGrid(columns: [
+                        GridItem(.flexible(), spacing: 8),
+                        GridItem(.flexible(), spacing: 8)
+                    ], spacing: 8) {
+                        ForEach(Array(capturedPhotos.enumerated()), id: \.offset) { _, photo in
+                            Image(uiImage: photo.image)
+                                .resizable()
+                                .scaledToFill()
+                                .frame(height: 160)
+                                .clipShape(RoundedRectangle(cornerRadius: 8))
+                        }
+                    }
+                }
+                .padding()
+            }
+
+            // Bottom actions
+            VStack(spacing: 12) {
+                HStack(spacing: 16) {
+                    Button {
+                        withAnimation { phase = .photoCapture }
+                    } label: {
+                        Text("Retake")
+                            .font(.headline)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 12)
+                    }
+                    .buttonStyle(.bordered)
+
+                    Button {
+                        saveAndDismiss()
+                    } label: {
+                        Text("Done")
+                            .font(.headline)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 12)
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+            }
+            .padding()
+            .background(.ultraThinMaterial)
+        }
+        .navigationTitle("Review Product")
+    }
+
+    // MARK: - Save & Dismiss
+
+    private func saveAndDismiss() {
+        let filenames = capturedPhotos.map(\.filename)
+        let record = ProductCaptureRecord(
+            barcodeValue: scannedBarcode,
+            symbology: scannedSymbology,
+            photoFileNames: filenames,
+            agentId: captureContext?.agentId,
+            agentName: captureContext?.agentName,
+            requestId: captureContext?.requestId.uuidString
+        )
+        modelContext.insert(record)
+        try? modelContext.save()
+
+        // Fire-and-forget nutrition lookup if barcode was scanned
+        if let upc = scannedBarcode {
+            let capturedApiService = apiService
+            let capturedContext = modelContext
+            Task {
+                await NutritionService.lookupForProduct(
+                    upc: upc, record: record,
+                    apiService: capturedApiService, modelContext: capturedContext
+                )
+            }
+        }
+
+        dismiss()
+    }
+
+    /// Delete any persisted photos on cancel (no orphaned files).
+    private func cleanupAndDismiss() {
+        if !capturedPhotos.isEmpty {
+            PhotoStorageService.delete(capturedPhotos.map(\.filename))
+        }
+        dismiss()
+    }
+}
+
+// MARK: - Single-Scan DataScanner (stops after first detection)
+
+private struct SingleScanRepresentable: UIViewControllerRepresentable {
+    let onScanned: (String, String) -> Void
+
+    func makeUIViewController(context: Context) -> DataScannerViewController {
+        let scanner = DataScannerViewController(
+            recognizedDataTypes: [.barcode()],
+            qualityLevel: .balanced,
+            isHighlightingEnabled: true
+        )
+        scanner.delegate = context.coordinator
+        try? scanner.startScanning()
+        return scanner
+    }
+
+    func updateUIViewController(_ uiViewController: DataScannerViewController, context: Context) {
+        if !uiViewController.isScanning {
+            try? uiViewController.startScanning()
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onScanned: onScanned)
+    }
+
+    class Coordinator: NSObject, DataScannerViewControllerDelegate {
+        let onScanned: (String, String) -> Void
+        private var hasScanned = false
+
+        init(onScanned: @escaping (String, String) -> Void) {
+            self.onScanned = onScanned
+        }
+
+        func dataScanner(_ dataScanner: DataScannerViewController, didAdd addedItems: [RecognizedItem], allItems: [RecognizedItem]) {
+            guard !hasScanned, let first = addedItems.first else { return }
+            guard case .barcode(let barcode) = first,
+                  let code = barcode.payloadStringValue else { return }
+            hasScanned = true
+            dataScanner.stopScanning()
+            let symbology = barcode.observation.symbology.rawValue
+            onScanned(code, symbology)
+        }
+    }
+}
+
+// MARK: - Product Photo Capture View (phase 2 of flow)
+
+private struct ProductPhotoCaptureView: View {
+    @Binding var capturedPhotos: [(image: UIImage, filename: String)]
+    let onDone: () -> Void
+
+    @State private var showingCapture = false
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if showingCapture {
+                ProductCameraView(onPhotoCaptured: handlePhotoCaptured, capturedPhotos: capturedPhotos)
+                    .ignoresSafeArea()
+
+                // Bottom bar with counter and done
+                VStack(spacing: 8) {
+                    if !capturedPhotos.isEmpty {
+                        // Thumbnail strip
+                        ScrollView(.horizontal, showsIndicators: false) {
+                            HStack(spacing: 6) {
+                                ForEach(Array(capturedPhotos.enumerated()), id: \.offset) { _, photo in
+                                    Image(uiImage: photo.image)
+                                        .resizable()
+                                        .scaledToFill()
+                                        .frame(width: 50, height: 50)
+                                        .clipShape(RoundedRectangle(cornerRadius: 6))
+                                }
+                            }
+                            .padding(.horizontal)
+                        }
+                        .frame(height: 56)
+                    }
+
+                    Text(counterText)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+
+                    Button {
+                        onDone()
+                    } label: {
+                        Text("Done")
+                            .font(.headline)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 12)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(capturedPhotos.isEmpty)
+                    .padding(.horizontal)
+                    .padding(.bottom, 8)
+                }
+                .background(.ultraThinMaterial)
+            } else {
+                // Instructions screen
+                instructionsView
+            }
+        }
+        .navigationTitle("Take Photos")
+    }
+
+    private var counterText: String {
+        if capturedPhotos.isEmpty {
+            return "Take 1–3 photos"
+        }
+        return "\(capturedPhotos.count) photo\(capturedPhotos.count == 1 ? "" : "s") captured"
+    }
+
+    private var instructionsView: some View {
+        VStack(spacing: 32) {
+            Spacer()
+
+            Image(systemName: "camera.fill")
+                .font(.system(size: 64))
+                .foregroundStyle(.orange)
+
+            Text("Product Photos")
+                .font(.title.bold())
+
+            VStack(alignment: .leading, spacing: 16) {
+                tipRow(icon: "1.circle.fill", text: "Front of package")
+                tipRow(icon: "2.circle.fill", text: "Nutrition label")
+                tipRow(icon: "3.circle", text: "Ingredients list (optional)")
+            }
+            .padding(.horizontal, 32)
+
+            Text("1–3 photos recommended")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+
+            Spacer()
+
+            Button {
+                showingCapture = true
+            } label: {
+                Text("Start Capturing")
+                    .font(.headline)
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color.orange)
+                    .foregroundStyle(.white)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+            }
+            .padding(.horizontal, 40)
+            .padding(.bottom, 40)
+        }
+    }
+
+    private func tipRow(icon: String, text: String) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: icon)
+                .font(.title3)
+                .foregroundStyle(.orange)
+                .frame(width: 28)
+            Text(text)
+                .font(.subheadline)
+        }
+    }
+
+    private func handlePhotoCaptured(_ image: UIImage) {
+        // Save to disk immediately
+        guard let filename = PhotoStorageService.save(image) else { return }
+        capturedPhotos.append((image: image, filename: filename))
+
+        let generator = UIImpactFeedbackGenerator(style: .medium)
+        generator.impactOccurred()
+        AudioServicesPlaySystemSound(1057)
+    }
+}
+
+// MARK: - Product Camera (AVCaptureSession wrapper for photo capture)
+
+private struct ProductCameraView: UIViewControllerRepresentable {
+    let onPhotoCaptured: (UIImage) -> Void
+    let capturedPhotos: [(image: UIImage, filename: String)]
+
+    func makeUIViewController(context: Context) -> ProductCameraController {
+        let controller = ProductCameraController()
+        controller.onPhotoCaptured = onPhotoCaptured
+        return controller
+    }
+
+    func updateUIViewController(_ controller: ProductCameraController, context: Context) {
+        controller.onPhotoCaptured = onPhotoCaptured
+    }
+}
+
+private class ProductCameraController: UIViewController, AVCapturePhotoCaptureDelegate {
+    private let captureSession = AVCaptureSession()
+    private let photoOutput = AVCapturePhotoOutput()
+    private var previewLayer: AVCaptureVideoPreviewLayer?
+    private let shutterButton = UIButton(type: .system)
+
+    var onPhotoCaptured: ((UIImage) -> Void)?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        checkPermissionAndSetup()
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        previewLayer?.frame = view.bounds
+    }
+
+    private func checkPermissionAndSetup() {
+        switch AVCaptureDevice.authorizationStatus(for: .video) {
+        case .authorized:
+            setupCamera()
+            setupShutterButton()
+        case .notDetermined:
+            AVCaptureDevice.requestAccess(for: .video) { [weak self] granted in
+                DispatchQueue.main.async {
+                    if granted {
+                        self?.setupCamera()
+                        self?.setupShutterButton()
+                    } else {
+                        self?.showPermissionDenied()
+                    }
+                }
+            }
+        default:
+            showPermissionDenied()
+        }
+    }
+
+    private func setupCamera() {
+        captureSession.sessionPreset = .photo
+        guard let camera = AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: .back),
+              let input = try? AVCaptureDeviceInput(device: camera) else { return }
+
+        if captureSession.canAddInput(input) { captureSession.addInput(input) }
+        if captureSession.canAddOutput(photoOutput) { captureSession.addOutput(photoOutput) }
+
+        let layer = AVCaptureVideoPreviewLayer(session: captureSession)
+        layer.videoGravity = .resizeAspectFill
+        layer.frame = view.bounds
+        view.layer.addSublayer(layer)
+        previewLayer = layer
+
+        Task.detached { [captureSession] in
+            captureSession.startRunning()
+        }
+    }
+
+    private func setupShutterButton() {
+        shutterButton.translatesAutoresizingMaskIntoConstraints = false
+        let config = UIImage.SymbolConfiguration(pointSize: 60, weight: .light)
+        shutterButton.setImage(UIImage(systemName: "circle.inset.filled", withConfiguration: config), for: .normal)
+        shutterButton.tintColor = .white
+        shutterButton.addTarget(self, action: #selector(capturePhoto), for: .touchUpInside)
+        view.addSubview(shutterButton)
+
+        NSLayoutConstraint.activate([
+            shutterButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            shutterButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -100)
+        ])
+    }
+
+    private func showPermissionDenied() {
+        let label = UILabel()
+        label.text = "Camera access denied.\nOpen Settings to enable."
+        label.textColor = .secondaryLabel
+        label.numberOfLines = 0
+        label.textAlignment = .center
+        label.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(label)
+        NSLayoutConstraint.activate([
+            label.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            label.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            label.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor, constant: 40)
+        ])
+    }
+
+    @objc private func capturePhoto() {
+        let settings = AVCapturePhotoSettings()
+        photoOutput.capturePhoto(with: settings, delegate: self)
+    }
+
+    func photoOutput(_ output: AVCapturePhotoOutput, didFinishProcessingPhoto photo: AVCapturePhoto, error: Error?) {
+        guard error == nil,
+              let data = photo.fileDataRepresentation(),
+              let image = UIImage(data: data) else { return }
+
+        // Compress to JPEG 0.8
+        guard let jpegData = image.jpegData(compressionQuality: 0.8),
+              let compressed = UIImage(data: jpegData) else {
+            DispatchQueue.main.async { [weak self] in
+                self?.onPhotoCaptured?(image)
+            }
+            return
+        }
+
+        DispatchQueue.main.async { [weak self] in
+            self?.onPhotoCaptured?(compressed)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **Chef agent demo**: Practical Chef asks user to scan a CPG product from their kitchen
- **Compound capture flow**: Optional barcode → multi-photo capture (1-3 photos) → review → save
- **Photo persistence**: Photos saved to disk with thumbnail generation for smooth history scrolling
- **V6 schema**: New `ProductCaptureRecord` model supports products with or without barcodes

## What's New

### Compound Capture Flow (`ProductScanFlowView`)
Three-phase flow within a single `.fullScreenCover`:
1. **Barcode scan** — single-scan mode with prominent "No barcode? Skip →" button
2. **Photo capture** — guided checklist (front of package, nutrition label), 1-3 photos recommended
3. **Review** — photo grid + barcode info, retake or confirm

### Photo Storage (`PhotoStorageService`)
- Full-res JPEG saved to Application Support on each shutter press
- 400px thumbnails generated at save time
- Cleanup on cancel (no orphaned files)

### History Updates
- `ProductCaptureRow` with first-photo thumbnail, product name, barcode, calorie badge
- `ProductDetailView` with scrollable photo gallery, nutrition data, agent attribution
- Products without barcodes display correctly with photo-based identification

### Agent Wiring
- New `.productScan` skill type on `AgentRequest.SkillType`
- Practical Chef updated with pending request and photo checklist
- `AgentsView` dispatches to compound flow, detects completion via `ProductCaptureRecord` count

## Test Plan
- [ ] Build succeeds (`xcodegen generate && xcodebuild`)
- [ ] Chef agent card appears in "Action Needed" with "Scan Product" button
- [ ] Barcode scan detects code, auto-advances to photos after brief toast
- [ ] "Skip" button advances directly to photo capture
- [ ] Photos saved to disk and visible in review screen
- [ ] "Done" creates `ProductCaptureRecord`, triggers sync animation
- [ ] Product appears in My Data > By Agent > Practical Chef
- [ ] Tapping product shows `ProductDetailView` with photo gallery
- [ ] Cancel cleans up any captured photos from disk
- [ ] Nutrition lookup populates product name/calories in history

Closes #95

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)