### PR TITLE
fix: Agent UX — camera permission, completion toast, polish

### DIFF
--- a/ios/Robo/Views/LiDARScanView.swift
+++ b/ios/Robo/Views/LiDARScanView.swift
@@ -41,6 +41,7 @@ struct LiDARScanView: View {
                             RoomResultView(
                                 room: capturedRoom,
                                 roomName: $roomName,
+                                isAgentSuggestedName: suggestedRoomName.map { !$0.trimmingCharacters(in: .whitespaces).isEmpty } ?? false,
                                 onSave: saveRoom,
                                 onDiscard: { dismiss() }
                             )

--- a/ios/Robo/Views/RoomResultView.swift
+++ b/ios/Robo/Views/RoomResultView.swift
@@ -4,6 +4,7 @@ import RoomPlan
 struct RoomResultView: View {
     let room: CapturedRoom
     @Binding var roomName: String
+    var isAgentSuggestedName: Bool = false
     let onSave: () -> Void
     let onDiscard: () -> Void
 
@@ -51,9 +52,16 @@ struct RoomResultView: View {
                     .font(.title.bold())
 
                 // Room name
-                TextField("Room name (optional)", text: $roomName)
-                    .textFieldStyle(.roundedBorder)
-                    .padding(.horizontal, 24)
+                if isAgentSuggestedName && !roomName.trimmingCharacters(in: .whitespaces).isEmpty {
+                    Text(roomName)
+                        .font(.headline)
+                        .foregroundStyle(.primary)
+                        .padding(.horizontal, 24)
+                } else {
+                    TextField("Room name (optional)", text: $roomName)
+                        .textFieldStyle(.roundedBorder)
+                        .padding(.horizontal, 24)
+                }
 
                 // Room dimensions headline
                 if let dims = roomDims {


### PR DESCRIPTION
## Summary

- **Fix photo capture white screen** — Add `AVCaptureDevice.requestAccess(for: .video)` before camera setup; show "Camera Access Required" with Settings deep link if denied
- **Safer fullScreenCover** — Use `item:` binding pattern instead of `if let` inside closure to prevent empty view on state timing issues
- **Completion toast** — Green "Response sent to [Agent Name]" toast after sync animation, auto-dismisses in 3 seconds
- **Rename "Connected" → "Agents Ready"** — Clearer section header for beta testers
- **Agent detail view** — Tap a ready agent to see icon, description, status, last sync date
- **Auto-save room name** — When agent provides `roomNameHint`, show read-only label instead of editable TextField
- **Skill type filter** — `enabledSkillTypes` set controls which agents are visible; safety net for hiding broken flows

## Files changed

| File | Changes |
|------|---------|
| `PhotoCaptureView.swift` | Camera permission check + denied state UI |
| `AgentsView.swift` | Toast overlay, skill filter, `item:` cover, detail view, rename |
| `RoomResultView.swift` | Conditional label vs TextField for agent-suggested name |
| `LiDARScanView.swift` | Pass `isAgentSuggestedName` flag to RoomResultView |

## Test plan

- [ ] Tap "Take Photos" on Smart Stylist → camera preview appears (not white screen)
- [ ] Deny camera permission → "Camera Access Required" screen with "Open Settings" button
- [ ] Complete any agent task → green "Response sent to [Agent]" toast appears at top
- [ ] Toast auto-dismisses after ~3 seconds
- [ ] "Connected" section now shows "Agents Ready"
- [ ] Tap a ready agent → detail view with icon, name, description, status
- [ ] Complete LiDAR scan for Interior Designer → room name auto-saved as "Master Bedroom" (no editable field)
- [ ] Build succeeds: `xcodebuild -scheme Robo -configuration Debug -destination 'generic/platform=iOS'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)