### PR TITLE
feat: custom domains api.robo.app + mcp.robo.app

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,4 +5,4 @@ APPLE_TEAM_ID=YOUR_TEAM_ID_HERE
 CLOUDFLARE_ACCOUNT_ID=YOUR_ACCOUNT_ID_HERE
 
 # API Configuration (optional - defaults to production)
-# API_BASE_URL=https://robo-api.silv.workers.dev
+# API_BASE_URL=https://api.robo.app

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,7 +199,7 @@ CLOUDFLARE_ACCOUNT_ID=<your-account-id>
 
 **D1 Database:** robo-db (`fb24f9a0-d52b-4a74-87ca-54069ec9471a`)
 **R2 Bucket:** robo-data
-**Workers API:** https://robo-api.silv.workers.dev
+**Workers API:** https://api.robo.app (also: https://mcp.robo.app for MCP)
 **Landing Page:** https://robo.app (Cloudflare Pages, source: `site/`)
 **Deploy landing page:** `wrangler pages deploy site --project-name=robo-app --commit-dirty=true --branch=main`
 

--- a/docs/cloudflare-resources.md
+++ b/docs/cloudflare-resources.md
@@ -16,7 +16,7 @@
 
 ## Workers
 - **Name:** robo-api
-- **URL:** https://robo-api.silv.workers.dev
+- **URL:** https://api.robo.app (custom domain), https://mcp.robo.app (MCP custom domain), https://robo-api.silv.workers.dev (workers.dev fallback)
 - **Version ID:** `98e106f7-db42-4791-ac6d-d9add74313e1`
 - **Main File:** `src/index.ts`
 - **Framework:** Hono + TypeScript

--- a/functions/hit/[id].ts
+++ b/functions/hit/[id].ts
@@ -14,7 +14,7 @@ interface HitData {
   photo_count: number;
 }
 
-const API_BASE = 'https://robo-api.silv.workers.dev';
+const API_BASE = 'https://api.robo.app';
 
 export const onRequest: PagesFunction = async (context) => {
   const hitId = context.params.id as string;

--- a/ios/Robo/Models/DeviceConfig.swift
+++ b/ios/Robo/Models/DeviceConfig.swift
@@ -12,7 +12,7 @@ struct DeviceConfig: Codable {
     static let `default` = DeviceConfig(
         id: unregisteredID,
         name: UIDevice.current.name,
-        apiBaseURL: "https://robo-api.silv.workers.dev"
+        apiBaseURL: "https://api.robo.app"
     )
 
     var isRegistered: Bool {

--- a/ios/Robo/Views/ClaudeCodeConnectionView.swift
+++ b/ios/Robo/Views/ClaudeCodeConnectionView.swift
@@ -6,7 +6,7 @@ struct ClaudeCodeConnectionView: View {
     @State private var copied = false
 
     private var connectionCommand: String {
-        "claude mcp add robo --transport http https://robo-api.silv.workers.dev/mcp --header \"Authorization: Bearer \(mcpToken)\""
+        "claude mcp add robo --transport http https://mcp.robo.app/mcp --header \"Authorization: Bearer \(mcpToken)\""
     }
 
     var body: some View {

--- a/workers/wrangler.toml
+++ b/workers/wrangler.toml
@@ -15,5 +15,13 @@ database_id = "fb24f9a0-d52b-4a74-87ca-54069ec9471a"
 binding = "BUCKET"
 bucket_name = "robo-data"
 
+[[routes]]
+pattern = "api.robo.app"
+custom_domain = true
+
+[[routes]]
+pattern = "mcp.robo.app"
+custom_domain = true
+
 [vars]
 ENVIRONMENT = "production"


### PR DESCRIPTION
## Summary
- Adds custom domains `api.robo.app` and `mcp.robo.app` to the Cloudflare Worker
- Replaces all functional references to `robo-api.silv.workers.dev` with shorter custom domains
- Fewer tokens for AI agents consuming these URLs
- Includes MCP device-scoped auth (from feat/mcp-device-auth commits)

## Changes
| File | Change |
|------|--------|
| `workers/wrangler.toml` | Added custom domain routes |
| `ios/Robo/Models/DeviceConfig.swift` | Default URL → `api.robo.app` |
| `ios/Robo/Views/ClaudeCodeConnectionView.swift` | MCP command → `mcp.robo.app` |
| `functions/hit/[id].ts` | API base → `api.robo.app` |
| `CLAUDE.md`, `.env.example`, `docs/cloudflare-resources.md` | Updated references |

## Verified
- `api.robo.app/health` → `{"status":"ok"}`
- `mcp.robo.app/mcp` + Bearer token → MCP initializes
- iOS build succeeded
- Zero remaining `robo-api.silv.workers.dev` in functional code

## Test plan
- [ ] `http GET https://api.robo.app/health --timeout=10` returns ok
- [ ] MCP auth flow works via `mcp.robo.app/mcp`
- [ ] `robo-api.silv.workers.dev` still works as fallback
- [ ] iOS app registers and connects via `api.robo.app`

🤖 Generated with [Claude Code](https://claude.com/claude-code)