### PR TITLE
ci: deploy workflows for landing page + Workers

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -1,0 +1,27 @@
+name: Deploy Landing Page
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths: ['site/**']
+
+concurrency:
+  group: deploy-site-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy site --project-name=robo-app --branch=main

--- a/.github/workflows/deploy-workers.yml
+++ b/.github/workflows/deploy-workers.yml
@@ -1,0 +1,71 @@
+name: Deploy Workers
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths: ['workers/**']
+
+concurrency:
+  group: deploy-workers-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: workers/package-lock.json
+
+      - name: Install dependencies
+        working-directory: workers
+        run: npm ci
+
+      - name: TypeScript check
+        working-directory: workers
+        run: npx tsc --noEmit
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: typecheck
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: workers/package-lock.json
+
+      - name: Install dependencies
+        working-directory: workers
+        run: npm ci
+
+      - name: Apply D1 migrations
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: d1 migrations apply robo-db --remote
+          workingDirectory: workers
+
+      - name: Deploy Worker
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy
+          workingDirectory: workers


### PR DESCRIPTION
## Summary

- **deploy-site.yml** — Auto-deploys `site/` to Cloudflare Pages on push to main (path filter: `site/**`)
- **deploy-workers.yml** — TypeScript check + D1 migrations + Worker deploy on push to main (path filter: `workers/**`)
- Both support `workflow_dispatch` for manual triggers

## Required Secrets

Add these to GitHub repo settings → Secrets → Actions:

| Secret | Description |
|--------|-------------|
| `CLOUDFLARE_API_TOKEN` | API token with Workers/Pages/D1 edit permissions |
| `CLOUDFLARE_ACCOUNT_ID` | Cloudflare account ID |

**To create the API token:**
1. Go to https://dash.cloudflare.com/profile/api-tokens
2. Create Token → Custom Token
3. Permissions: `Account / Cloudflare Pages / Edit`, `Account / Workers Scripts / Edit`, `Account / D1 / Edit`
4. Account Resources: include your account

## Test plan

- [ ] Add `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` secrets
- [ ] Merge → verify deploy-site triggers (site/** changed)
- [ ] Push a workers/ change → verify deploy-workers triggers with typecheck + migration + deploy
- [ ] Manual trigger: `gh workflow run deploy-site.yml` and `gh workflow run deploy-workers.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)