### PR TITLE
fix: improve registration error diagnostics (#142)

### DIFF
--- a/ios/Robo/Services/DeviceService.swift
+++ b/ios/Robo/Services/DeviceService.swift
@@ -67,6 +67,12 @@ class DeviceService {
     /// Clear local config and re-register to get a fresh device with MCP token.
     /// Use when the device was registered before auth existed.
     func reRegister(apiService: DeviceRegistering) async {
+        // Quick connectivity check before wiping config
+        if let api = apiService as? APIService, !(await api.checkHealth()) {
+            self.registrationError = "Cannot reach server. Check your internet connection and try again."
+            return
+        }
+
         let previousConfig = config
         let savedBaseURL = config.apiBaseURL
         config = DeviceConfig(


### PR DESCRIPTION
## Summary
- `APIError` now conforms to `LocalizedError` — users see "Unexpected server response" instead of cryptic "RoboAPI error 2"
- Added `#if DEBUG` logging in `performRequest` for all error paths (logs URL, status code, response body preview)
- Added `/health` pre-check in `reRegister()` to catch connectivity issues before wiping device config

Closes #142

## Context
"RoboAPI error 2" was actually Swift's `APIError.invalidResponse` (enum ordinal 2), not a server error code. The server works fine — the issue was that all error context was discarded, making diagnosis impossible, and the error message was unhelpful.

## Files Changed
| File | Change |
|------|--------|
| `ios/Robo/Services/APIService.swift` | `LocalizedError` conformance, debug logging, `checkHealth()` |
| `ios/Robo/Services/DeviceService.swift` | Health check before re-register |

## Test Plan
- [x] Build succeeds (0 errors, xcsift verified)
- [ ] Test re-register on physical device with good connectivity
- [ ] Test re-register with airplane mode (should show "Cannot reach server")
- [ ] Verify debug logs appear in Xcode console on failure

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: Changes are iOS-only (error messages + debug logging). No backend changes. Debug logging is `#if DEBUG` only — not present in release builds.

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)