### PR TITLE
fix: simplify My Data, remove location prompts, consolidate motion

### DIFF
--- a/ios/Robo/Info.plist
+++ b/ios/Robo/Info.plist
@@ -30,11 +30,7 @@
 	<string>Robo reads your sleep, workout, and activity data to share with your AI agents.</string>
 	<key>NSHealthUpdateUsageDescription</key>
 	<string>Robo does not write health data, but HealthKit requires this description.</string>
-	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
-	<string>Robo needs background location access to detect beacons when the app is closed, triggering room-based automations.</string>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>Robo uses your location to detect nearby Bluetooth beacons for room-based automations.</string>
-	<key>NSMotionUsageDescription</key>
+<key>NSMotionUsageDescription</key>
 	<string>Robo needs motion access to capture step count, distance, and activity data for AI analysis</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Robo needs photo library access to save captured images</string>
@@ -59,7 +55,6 @@
 	<true/>
 	<key>UIBackgroundModes</key>
 	<array>
-		<string>location</string>
 		<string>bluetooth-central</string>
 		<string>remote-notification</string>
 	</array>

--- a/ios/Robo/Services/BeaconService.swift
+++ b/ios/Robo/Services/BeaconService.swift
@@ -63,22 +63,19 @@ class BeaconService: NSObject, CLLocationManagerDelegate {
     // MARK: - Public API
 
     func requestPermissions() {
-        if manager.authorizationStatus == .notDetermined {
-            manager.requestWhenInUseAuthorization()
-        } else if manager.authorizationStatus == .authorizedWhenInUse {
-            manager.requestAlwaysAuthorization()
-        }
+        // Location permissions disabled for now — beacon monitoring requires location
+        // but we don't want to prompt users for location access yet.
+        logger.info("Location permissions request suppressed")
     }
 
     /// Requests permissions and starts monitoring once authorized.
-    /// Handles the race condition where startMonitoring() is called before auth is granted.
     func requestPermissionsAndMonitor() {
         let status = manager.authorizationStatus
         if status == .authorizedAlways || status == .authorizedWhenInUse {
             startMonitoring()
         } else {
-            pendingMonitorAfterAuth = true
-            requestPermissions()
+            // Don't request permissions — just log
+            logger.info("Beacon monitoring requires location permission (not requesting)")
         }
     }
 
@@ -129,11 +126,6 @@ class BeaconService: NSObject, CLLocationManagerDelegate {
     func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
         authorizationStatus = manager.authorizationStatus
         logger.info("Authorization changed: \(String(describing: manager.authorizationStatus.rawValue))")
-
-        // After WhenInUse is granted, request Always for background monitoring
-        if manager.authorizationStatus == .authorizedWhenInUse {
-            manager.requestAlwaysAuthorization()
-        }
 
         // Start monitoring if it was deferred pending authorization
         if pendingMonitorAfterAuth,

--- a/ios/Robo/Services/MotionService.swift
+++ b/ios/Robo/Services/MotionService.swift
@@ -10,8 +10,12 @@ struct MotionSnapshot: Sendable {
 
     struct ActivityPeriod: Sendable, Codable {
         let startDate: Date
+        let endDate: Date
         let type: String
         let confidence: String
+        var durationMinutes: Int {
+            Int(endDate.timeIntervalSince(startDate) / 60)
+        }
     }
 }
 
@@ -58,13 +62,7 @@ enum MotionService {
             }
         }
 
-        let activities = rawActivities.map { activity in
-            MotionSnapshot.ActivityPeriod(
-                startDate: activity.startDate,
-                type: classifyActivity(activity),
-                confidence: confidenceString(activity.confidence)
-            )
-        }
+        let activities = consolidateActivities(rawActivities, endDate: now)
 
         return MotionSnapshot(
             stepCount: pedometerData.numberOfSteps.intValue,
@@ -83,12 +81,14 @@ enum MotionService {
 
         let distanceMiles = snapshot.distanceMeters * metersToMiles
 
-        let activitiesArray: [[String: String]] = snapshot.activities.map { period in
+        let activitiesArray: [[String: Any]] = snapshot.activities.map { period in
             [
                 "start_time": formatter.string(from: period.startDate),
+                "end_time": formatter.string(from: period.endDate),
                 "activity_type": period.type,
+                "duration_minutes": period.durationMinutes,
                 "confidence": period.confidence
-            ]
+            ] as [String: Any]
         }
 
         let dict: [String: Any] = [
@@ -106,6 +106,59 @@ enum MotionService {
         ]
 
         return try JSONSerialization.data(withJSONObject: dict, options: [.prettyPrinted, .sortedKeys])
+    }
+
+    // MARK: - Activity Consolidation
+
+    /// Merges consecutive same-type activities and drops periods shorter than 5 minutes.
+    private static func consolidateActivities(_ rawActivities: [CMMotionActivity], endDate: Date) -> [MotionSnapshot.ActivityPeriod] {
+        guard !rawActivities.isEmpty else { return [] }
+        let minDurationSeconds: TimeInterval = 5 * 60 // 5 minutes
+
+        var consolidated: [MotionSnapshot.ActivityPeriod] = []
+        var currentType = classifyActivity(rawActivities[0])
+        var currentConfidence = confidenceString(rawActivities[0].confidence)
+        var currentStart = rawActivities[0].startDate
+
+        for i in 1..<rawActivities.count {
+            let actType = classifyActivity(rawActivities[i])
+            let actConf = confidenceString(rawActivities[i].confidence)
+            let actStart = rawActivities[i].startDate
+
+            if actType == currentType {
+                // Merge: extend current period, keep best confidence
+                if actConf == "high" || (actConf == "medium" && currentConfidence == "low") {
+                    currentConfidence = actConf
+                }
+            } else {
+                // End current period
+                let duration = actStart.timeIntervalSince(currentStart)
+                if duration >= minDurationSeconds && currentType != "unknown" {
+                    consolidated.append(MotionSnapshot.ActivityPeriod(
+                        startDate: currentStart,
+                        endDate: actStart,
+                        type: currentType,
+                        confidence: currentConfidence
+                    ))
+                }
+                currentType = actType
+                currentConfidence = actConf
+                currentStart = actStart
+            }
+        }
+
+        // Close final period
+        let finalDuration = endDate.timeIntervalSince(currentStart)
+        if finalDuration >= minDurationSeconds && currentType != "unknown" {
+            consolidated.append(MotionSnapshot.ActivityPeriod(
+                startDate: currentStart,
+                endDate: endDate,
+                type: currentType,
+                confidence: currentConfidence
+            ))
+        }
+
+        return consolidated
     }
 
     // MARK: - Helpers

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -65,13 +65,9 @@ targets:
         NSCameraUsageDescription: "Robo needs camera access to scan barcodes, capture photos, and perform LiDAR room scanning for AI analysis"
         NSPhotoLibraryUsageDescription: "Robo needs photo library access to save captured images"
         NSMotionUsageDescription: "Robo needs motion access to capture step count, distance, and activity data for AI analysis"
-        NSLocationWhenInUseUsageDescription: "Robo uses your location to detect nearby Bluetooth beacons for room-based automations."
-        NSLocationAlwaysAndWhenInUseUsageDescription: "Robo needs background location access to detect beacons when the app is closed, triggering room-based automations."
         NSBluetoothAlwaysUsageDescription: "Robo uses Bluetooth to detect nearby iBeacon devices for room-aware automations."
         NSHealthShareUsageDescription: "Robo reads your sleep, workout, and activity data to share with your AI agents."
         NSHealthUpdateUsageDescription: "Robo does not write health data, but HealthKit requires this description."
-        UIBackgroundModes:
-          - location
           - bluetooth-central
           - remote-notification
 


### PR DESCRIPTION
## Summary
- **My Data simplified**: Removed By Agent/By Type picker — now shows By Type view directly with Quick Capture section on all lists
- **No more location prompts**: Beacon service no longer requests location authorization; removed plist keys and background location mode
- **Motion data cleaned up**: Activities consolidated (merge consecutive same-type, drop <5min and unknown), duration shown in detail view

## Test plan
- [ ] Open My Data tab — should show type picker (Barcodes/Rooms/Motion/Beacons) directly, no By Agent toggle
- [ ] Each type list should have Quick Capture section at bottom
- [ ] Launch app fresh — should NOT see location permission prompt
- [ ] Capture motion data — verify activity count is reasonable (not 9000+) and durations display

🤖 Generated with [Claude Code](https://claude.com/claude-code)