### PR TITLE
feat: MCP room scan guidance + download endpoint + 3D viewer

### DIFF
--- a/site/static/room-viewer.html
+++ b/site/static/room-viewer.html
@@ -1,0 +1,263 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Robo Room Viewer</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { background: #1a1a2e; overflow: hidden; font-family: -apple-system, system-ui, sans-serif; }
+  #canvas { width: 100vw; height: 100vh; display: block; }
+  #stats {
+    position: fixed; top: 16px; left: 16px; background: rgba(0,0,0,0.75);
+    color: #e0e0e0; padding: 16px; border-radius: 12px; font-size: 13px;
+    line-height: 1.6; backdrop-filter: blur(8px); min-width: 200px;
+    border: 1px solid rgba(255,255,255,0.1);
+  }
+  #stats h2 { color: #4fc3f7; font-size: 15px; margin-bottom: 8px; }
+  #stats .label { color: #999; }
+  #tooltip {
+    display: none; position: fixed; background: rgba(0,0,0,0.85);
+    color: #fff; padding: 10px 14px; border-radius: 8px; font-size: 13px;
+    pointer-events: none; z-index: 100; border: 1px solid rgba(79,195,247,0.4);
+  }
+  #legend {
+    position: fixed; bottom: 16px; left: 16px; background: rgba(0,0,0,0.75);
+    color: #e0e0e0; padding: 12px 16px; border-radius: 12px; font-size: 12px;
+    backdrop-filter: blur(8px); border: 1px solid rgba(255,255,255,0.1);
+  }
+  #legend span { margin-right: 14px; }
+  #legend .dot { display: inline-block; width: 10px; height: 10px; border-radius: 50%; margin-right: 4px; vertical-align: middle; }
+</style>
+</head>
+<body>
+<canvas id="canvas"></canvas>
+<div id="stats"></div>
+<div id="tooltip"></div>
+<div id="legend">
+  <span><span class="dot" style="background:#a0a0a0"></span>Walls</span>
+  <span><span class="dot" style="background:#e8d5b7"></span>Floor</span>
+  <span><span class="dot" style="background:#5d4037"></span>Table</span>
+  <span><span class="dot" style="background:#d7ccc8"></span>Chair</span>
+  <span><span class="dot" style="background:#5c6bc0"></span>Bed</span>
+  <span><span class="dot" style="background:#66bb6a"></span>Sofa</span>
+  <span><span class="dot" style="background:#42a5f5"></span>Door</span>
+  <span><span class="dot" style="background:#ffca28"></span>Window</span>
+</div>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "https://cdn.jsdelivr.net/npm/three@0.170.0/build/three.module.js",
+    "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.170.0/examples/jsm/"
+  }
+}
+</script>
+<script type="module">
+import * as THREE from 'three';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+
+const ROOM_DATA = {{ROOM_DATA}};
+
+const CATEGORY_COLORS = {
+  table: 0x5d4037, chair: 0xd7ccc8, bed: 0x5c6bc0, sofa: 0x66bb6a,
+  storage: 0x8d6e63, screen: 0x37474f, bathtub: 0x4dd0e1, sink: 0x80cbc4,
+  toilet: 0xeeeeee, oven: 0x616161, refrigerator: 0xb0bec5, washerDryer: 0x78909c,
+  stove: 0x424242, fireplace: 0xff7043, stairs: 0x9e9e9e,
+};
+const DEFAULT_OBJ_COLOR = 0xce93d8;
+
+// Scene setup
+const canvas = document.getElementById('canvas');
+const renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
+renderer.setSize(window.innerWidth, window.innerHeight);
+renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+renderer.toneMapping = THREE.ACESFilmicToneMapping;
+renderer.toneMappingExposure = 1.2;
+
+const scene = new THREE.Scene();
+scene.background = new THREE.Color(0x1a1a2e);
+scene.fog = new THREE.Fog(0x1a1a2e, 20, 40);
+
+const camera = new THREE.PerspectiveCamera(50, window.innerWidth / window.innerHeight, 0.1, 100);
+camera.position.set(6, 5, 6);
+
+const controls = new OrbitControls(camera, canvas);
+controls.enableDamping = true;
+controls.dampingFactor = 0.05;
+controls.target.set(0, 1, 0);
+
+// Lighting
+scene.add(new THREE.AmbientLight(0xffffff, 0.4));
+const dirLight = new THREE.DirectionalLight(0xffffff, 0.8);
+dirLight.position.set(5, 10, 5);
+scene.add(dirLight);
+const hemiLight = new THREE.HemisphereLight(0x87ceeb, 0x362d2d, 0.3);
+scene.add(hemiLight);
+
+// Grid
+const grid = new THREE.GridHelper(20, 20, 0x333355, 0x222244);
+scene.add(grid);
+
+// Helpers
+function matrixFromColumns(cols) {
+  const m = new THREE.Matrix4();
+  m.set(
+    cols[0][0], cols[1][0], cols[2][0], cols[3][0],
+    cols[0][1], cols[1][1], cols[2][1], cols[3][1],
+    cols[0][2], cols[1][2], cols[2][2], cols[3][2],
+    cols[0][3], cols[1][3], cols[2][3], cols[3][3]
+  );
+  return m;
+}
+
+const clickables = [];
+const toFt = m => (m * 3.28084).toFixed(1);
+
+// Render walls
+for (const wall of (ROOM_DATA.walls || [])) {
+  const d = wall.dimensions;
+  const geo = new THREE.BoxGeometry(d.x, d.y, d.z || 0.1);
+  const mat = new THREE.MeshStandardMaterial({
+    color: 0xa0a0a0, transparent: true, opacity: 0.6, roughness: 0.8,
+  });
+  const mesh = new THREE.Mesh(geo, mat);
+  mesh.applyMatrix4(matrixFromColumns(wall.transform.columns));
+  mesh.userData = { type: 'Wall', width: toFt(d.x), height: toFt(d.y) };
+  scene.add(mesh);
+  clickables.push(mesh);
+
+  // Wireframe overlay
+  const wire = new THREE.LineSegments(
+    new THREE.EdgesGeometry(geo),
+    new THREE.LineBasicMaterial({ color: 0x4fc3f7, transparent: true, opacity: 0.3 })
+  );
+  wire.applyMatrix4(matrixFromColumns(wall.transform.columns));
+  scene.add(wire);
+}
+
+// Render floors
+for (const floor of (ROOM_DATA.floors || [])) {
+  if (floor.polygonCorners && floor.polygonCorners.length >= 3) {
+    const shape = new THREE.Shape();
+    const corners = floor.polygonCorners;
+    shape.moveTo(corners[0].x, corners[0].z);
+    for (let i = 1; i < corners.length; i++) {
+      shape.lineTo(corners[i].x, corners[i].z);
+    }
+    shape.closePath();
+    const geo = new THREE.ShapeGeometry(shape);
+    geo.rotateX(-Math.PI / 2);
+    const y = corners[0].y || 0;
+    const mat = new THREE.MeshStandardMaterial({
+      color: 0xe8d5b7, roughness: 0.9, side: THREE.DoubleSide,
+    });
+    const mesh = new THREE.Mesh(geo, mat);
+    mesh.position.y = y;
+    const d = floor.dimensions || {};
+    mesh.userData = { type: 'Floor', width: toFt(d.x || 0), depth: toFt(d.z || 0) };
+    scene.add(mesh);
+    clickables.push(mesh);
+  }
+}
+
+// Render doors
+for (const door of (ROOM_DATA.doors || [])) {
+  const d = door.dimensions;
+  const geo = new THREE.BoxGeometry(d.x, d.y, d.z || 0.08);
+  const mat = new THREE.MeshStandardMaterial({ color: 0x42a5f5, transparent: true, opacity: 0.5 });
+  const mesh = new THREE.Mesh(geo, mat);
+  mesh.applyMatrix4(matrixFromColumns(door.transform.columns));
+  mesh.userData = { type: 'Door', width: toFt(d.x), height: toFt(d.y) };
+  scene.add(mesh);
+  clickables.push(mesh);
+}
+
+// Render windows
+for (const win of (ROOM_DATA.windows || [])) {
+  const d = win.dimensions;
+  const geo = new THREE.BoxGeometry(d.x, d.y, d.z || 0.06);
+  const mat = new THREE.MeshStandardMaterial({ color: 0xffca28, transparent: true, opacity: 0.4 });
+  const mesh = new THREE.Mesh(geo, mat);
+  mesh.applyMatrix4(matrixFromColumns(win.transform.columns));
+  mesh.userData = { type: 'Window', width: toFt(d.x), height: toFt(d.y) };
+  scene.add(mesh);
+  clickables.push(mesh);
+}
+
+// Render objects
+for (const obj of (ROOM_DATA.objects || [])) {
+  const d = obj.dimensions;
+  const geo = new THREE.BoxGeometry(d.x, d.y, d.z);
+  const color = CATEGORY_COLORS[obj.category] ?? DEFAULT_OBJ_COLOR;
+  const mat = new THREE.MeshStandardMaterial({ color, transparent: true, opacity: 0.7, roughness: 0.6 });
+  const mesh = new THREE.Mesh(geo, mat);
+  mesh.applyMatrix4(matrixFromColumns(obj.transform.columns));
+  mesh.userData = { type: obj.category, width: toFt(d.x), height: toFt(d.y), depth: toFt(d.z) };
+  scene.add(mesh);
+  clickables.push(mesh);
+}
+
+// Center camera on scene
+const box = new THREE.Box3().setFromObject(scene);
+const center = box.getCenter(new THREE.Vector3());
+controls.target.copy(center);
+camera.position.set(center.x + 6, center.y + 5, center.z + 6);
+
+// Stats overlay
+const walls = ROOM_DATA.walls || [];
+const floors = ROOM_DATA.floors || [];
+const totalWallArea = walls.reduce((s, w) => s + (w.dimensions.x * w.dimensions.y), 0);
+const totalFloorArea = floors.reduce((s, f) => s + ((f.dimensions?.x || 0) * (f.dimensions?.z || 0)), 0);
+document.getElementById('stats').innerHTML = `
+  <h2>Room Scan</h2>
+  <span class="label">Walls:</span> ${walls.length}<br>
+  <span class="label">Doors:</span> ${(ROOM_DATA.doors||[]).length}<br>
+  <span class="label">Windows:</span> ${(ROOM_DATA.windows||[]).length}<br>
+  <span class="label">Objects:</span> ${(ROOM_DATA.objects||[]).length}<br>
+  <span class="label">Wall area:</span> ${(totalWallArea * 10.7639).toFixed(0)} sqft<br>
+  <span class="label">Floor area:</span> ${(totalFloorArea * 10.7639).toFixed(0)} sqft
+`;
+
+// Tooltip on click
+const raycaster = new THREE.Raycaster();
+const mouse = new THREE.Vector2();
+const tooltip = document.getElementById('tooltip');
+
+canvas.addEventListener('click', (e) => {
+  mouse.x = (e.clientX / window.innerWidth) * 2 - 1;
+  mouse.y = -(e.clientY / window.innerHeight) * 2 + 1;
+  raycaster.setFromCamera(mouse, camera);
+  const hits = raycaster.intersectObjects(clickables);
+  if (hits.length) {
+    const data = hits[0].object.userData;
+    const lines = [`<b>${data.type}</b>`];
+    if (data.width) lines.push(`Width: ${data.width} ft`);
+    if (data.height) lines.push(`Height: ${data.height} ft`);
+    if (data.depth) lines.push(`Depth: ${data.depth} ft`);
+    tooltip.innerHTML = lines.join('<br>');
+    tooltip.style.display = 'block';
+    tooltip.style.left = e.clientX + 12 + 'px';
+    tooltip.style.top = e.clientY + 12 + 'px';
+  } else {
+    tooltip.style.display = 'none';
+  }
+});
+
+// Resize
+window.addEventListener('resize', () => {
+  camera.aspect = window.innerWidth / window.innerHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize(window.innerWidth, window.innerHeight);
+});
+
+// Animate
+function animate() {
+  requestAnimationFrame(animate);
+  controls.update();
+  renderer.render(scene, camera);
+}
+animate();
+</script>
+</body>
+</html>

--- a/workers/src/index.ts
+++ b/workers/src/index.ts
@@ -9,7 +9,7 @@ import { registerDevice, getDevice, saveAPNsToken } from './routes/devices';
 import { submitSensorData } from './routes/sensors';
 import { getInbox, pushCard, respondToCard } from './routes/inbox';
 import { analyzeWithOpus } from './routes/opus';
-import { debugSync, debugList, debugGet } from './routes/debug';
+import { debugSync, debugList, debugGet, debugDownload } from './routes/debug';
 import { lookupNutrition } from './routes/nutrition';
 import { createHit, getHit, uploadHitPhoto, completeHit, listHits, listHitPhotos, respondToHit, listHitResponses } from './routes/hits';
 import { deviceAuth } from './middleware/deviceAuth';
@@ -60,6 +60,7 @@ app.get('/api/hits/:id/responses', listHitResponses);
 app.post('/api/debug/sync', debugSync);
 app.get('/api/debug/sync/:device_id', debugList);
 app.get('/api/debug/sync/:device_id/:key{.+}', debugGet);
+app.get('/api/debug/download/:key{.+}', debugDownload);
 
 // Error handling
 app.onError((err, c) => {


### PR DESCRIPTION
## Summary
- **MCP `get_debug_payload`** now returns a compact summary for room scans (stats, schema, engineering guidance) instead of dumping raw JSON into context
- **New `/api/debug/download/:key`** endpoint for authenticated R2 downloads — Claude Code saves full scan to disk instead of loading into context
- **Three.js room viewer template** at `/static/room-viewer.html` — self-contained HTML with `{{ROOM_DATA}}` placeholder for JSON injection

## Why
The phone is the sensor; Claude Code is the engineer. Instead of flooding the context window with 500KB of raw JSON, the MCP now teaches Claude Code what it can *build*: 3D viewers, paint estimates, furniture fit checks, floor plan SVGs.

## Test plan
- [ ] Deploy worker: `cd workers && npm run deploy`
- [ ] Deploy site: `wrangler pages deploy site --project-name=robo-app --commit-dirty=true --branch=main`
- [ ] Call `get_debug_payload` via MCP on a room scan → verify summary response (not raw JSON)
- [ ] Download full scan via `/api/debug/download/:key` with Bearer token
- [ ] Generate viewer: download template → replace `{{ROOM_DATA}}` → open in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)