### PR TITLE
fix: Coindex upload — persist photos to disk + retain OAuth session

### DIFF
--- a/ios/Robo/Views/ChatView.swift
+++ b/ios/Robo/Views/ChatView.swift
@@ -15,6 +15,7 @@ struct ChatView: View {
     @State private var roomCountBeforeCapture = 0
     @State private var barcodeCountBeforeCapture = 0
     @State private var photoCapturedCount = 0
+    @State private var capturedFilenames: [String] = []
     @FocusState private var isInputFocused: Bool
 
     private let suggestionChips = [
@@ -92,7 +93,7 @@ struct ChatView: View {
             BarcodeScannerView()
                 .onAppear { recordCountsBefore() }
         case .photo:
-            PhotoCaptureView(agentName: "Chat Assistant", checklist: [], photoCapturedCount: $photoCapturedCount)
+            PhotoCaptureView(agentName: "Chat Assistant", checklist: [], photoCapturedCount: $photoCapturedCount, capturedFilenames: $capturedFilenames)
                 .onAppear { recordCountsBefore() }
         }
     }
@@ -131,13 +132,15 @@ struct ChatView: View {
             }
 
         case .photo:
-            if photoCapturedCount > 0 {
+            if !capturedFilenames.isEmpty {
+                let names = capturedFilenames.joined(separator: ", ")
                 captureCoordinator.completeCapture(
-                    result: "Photo capture completed. \(photoCapturedCount) photo\(photoCapturedCount == 1 ? "" : "s") saved."
+                    result: "Captured \(capturedFilenames.count) photos: \(names)"
                 )
             } else {
                 captureCoordinator.cancelCapture()
             }
+            capturedFilenames = []
             photoCapturedCount = 0
         }
     }

--- a/ios/Robo/Views/PhotoCaptureView.swift
+++ b/ios/Robo/Views/PhotoCaptureView.swift
@@ -10,6 +10,7 @@ struct PhotoCaptureView: View {
     let agentName: String
     let checklist: [PhotoTask]
     @Binding var photoCapturedCount: Int
+    @Binding var capturedFilenames: [String]
 
     @State private var phase: CapturePhase = .instructions
     @State private var capturedPhotos: [CapturedPhoto] = []
@@ -29,11 +30,12 @@ struct PhotoCaptureView: View {
         let capturedAt: Date
     }
 
-    init(captureContext: CaptureContext? = nil, agentName: String, checklist: [PhotoTask], photoCapturedCount: Binding<Int> = .constant(0)) {
+    init(captureContext: CaptureContext? = nil, agentName: String, checklist: [PhotoTask], photoCapturedCount: Binding<Int> = .constant(0), capturedFilenames: Binding<[String]> = .constant([])) {
         self.captureContext = captureContext
         self.agentName = agentName
         self.checklist = checklist
         self._photoCapturedCount = photoCapturedCount
+        self._capturedFilenames = capturedFilenames
         self._checklistState = State(initialValue: checklist)
     }
 
@@ -167,6 +169,11 @@ struct PhotoCaptureView: View {
         let photo = CapturedPhoto(image: image, label: label, capturedAt: Date())
         capturedPhotos.append(photo)
         photoCapturedCount = capturedPhotos.count
+
+        // Persist to disk so filenames are available for upload tools
+        if let filename = PhotoStorageService.save(image) {
+            capturedFilenames.append(filename)
+        }
 
         // Haptic
         let generator = UIImpactFeedbackGenerator(style: .medium)


### PR DESCRIPTION
## Summary
- **[P0] Photo persistence:** `PhotoCaptureView` now saves each captured photo to disk via `PhotoStorageService.save()` and passes filenames back through a `@Binding var capturedFilenames`. `ChatView` includes these filenames in the capture result string (`"Captured 3 photos: UUID1.jpg, UUID2.jpg, UUID3.jpg"`), which `UploadCoinsToCoindexTool` already parses for `.jpg` filenames.
- **[P1] OAuth session retention:** `CoindexService.authenticate()` now retains the `ASWebAuthenticationSession` as an instance property (`authSession`) to prevent ARC from deallocating it before the callback fires. Cleared in the callback.

## Test plan
- [ ] "Upload coins to coindex" in chat → OAuth sheet appears and stays open
- [ ] Complete OAuth → take photos → verify filenames appear in capture result
- [ ] Photos upload successfully to Coindex album
- [ ] Cancel photo capture → verify no crash, graceful cancellation

🤖 Generated with [Claude Code](https://claude.com/claude-code)