### PR TITLE
feat: Keychain persistence + 30-day API key expiry

### DIFF
--- a/ios/Robo/Models/APIKey.swift
+++ b/ios/Robo/Models/APIKey.swift
@@ -6,11 +6,23 @@ struct APIKeyMeta: Codable, Identifiable {
     let keyHint: String
     let label: String?
     let createdAt: String
+    let expiresAt: String?
 
     enum CodingKeys: String, CodingKey {
         case id, label
         case keyHint = "key_hint"
         case createdAt = "created_at"
+        case expiresAt = "expires_at"
+    }
+
+    var expiresDate: Date? {
+        guard let s = expiresAt else { return nil }
+        return ISO8601DateFormatter().date(from: s)
+    }
+
+    var daysRemaining: Int? {
+        guard let exp = expiresDate else { return nil }
+        return max(0, Calendar.current.dateComponents([.day], from: Date(), to: exp).day ?? 0)
     }
 }
 
@@ -20,11 +32,13 @@ struct APIKeyCreated: Decodable {
     let keyValue: String
     let label: String?
     let createdAt: String
+    let expiresAt: String?
 
     enum CodingKeys: String, CodingKey {
         case id, label
         case keyValue = "key_value"
         case createdAt = "created_at"
+        case expiresAt = "expires_at"
     }
 }
 

--- a/ios/Robo/Services/KeychainHelper.swift
+++ b/ios/Robo/Services/KeychainHelper.swift
@@ -1,0 +1,50 @@
+import Foundation
+import Security
+
+/// Minimal Keychain wrapper for storing DeviceConfig across app reinstalls.
+enum KeychainHelper {
+    private static let service = "com.silv.Robo"
+    private static let account = "deviceConfig"
+
+    static func save(_ config: DeviceConfig) {
+        guard let data = try? JSONEncoder().encode(config) else { return }
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+
+        // Delete existing, then add (simpler than update logic)
+        SecItemDelete(query as CFDictionary)
+
+        var addQuery = query
+        addQuery[kSecValueData as String] = data
+        addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+        SecItemAdd(addQuery as CFDictionary, nil)
+    }
+
+    static func load() -> DeviceConfig? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess, let data = result as? Data else { return nil }
+        return try? JSONDecoder().decode(DeviceConfig.self, from: data)
+    }
+
+    static func delete() {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+}

--- a/ios/Robo/Views/DeveloperPortalView.swift
+++ b/ios/Robo/Views/DeveloperPortalView.swift
@@ -52,6 +52,11 @@ struct DeveloperPortalView: View {
                             Text(key.keyHint)
                                 .font(.caption.monospaced())
                                 .foregroundStyle(.secondary)
+                            if let days = key.daysRemaining {
+                                Text("Expires in \(days) day\(days == 1 ? "" : "s")")
+                                    .font(.caption2)
+                                    .foregroundStyle(days <= 7 ? .orange : .secondary)
+                            }
                         }
                         Spacer()
                         if isDeleting.contains(key.id) {
@@ -76,7 +81,7 @@ struct DeveloperPortalView: View {
         } header: {
             Text("API Keys")
         } footer: {
-            Text("Maximum 3 keys per device. Full key is shown only once on creation. Swipe to delete.")
+            Text("Maximum 3 keys per device. Keys expire after 30 days. Full key shown only once on creation. Swipe to delete.")
         }
         .alert("New API Key", isPresented: $showCreateAlert) {
             TextField("Label (optional)", text: $newKeyLabel)

--- a/workers/src/routes/apikeys.test.ts
+++ b/workers/src/routes/apikeys.test.ts
@@ -82,7 +82,7 @@ describe('POST /api/keys', () => {
 });
 
 describe('GET /api/keys (list with data)', () => {
-	it('returns masked keys, not full values', async () => {
+	it('returns masked keys with expiry, not full values', async () => {
 		const headers = {
 			'X-Device-ID': 'dev-1',
 			Authorization: 'Bearer token-abc-123',
@@ -92,10 +92,11 @@ describe('GET /api/keys (list with data)', () => {
 			method: 'POST', headers, body: JSON.stringify({ label: 'test' }),
 		});
 		const resp = await SELF.fetch('https://api.robo.app/api/keys', { headers });
-		const body = await resp.json() as { keys: Array<{ key_hint: string; key_value?: string }> };
+		const body = await resp.json() as { keys: Array<{ key_hint: string; key_value?: string; expires_at?: string }> };
 		expect(body.keys).toHaveLength(1);
 		expect(body.keys[0].key_hint).toContain('••••');
 		expect(body.keys[0]).not.toHaveProperty('key_value');
+		expect(body.keys[0].expires_at).toBeDefined();
 	});
 });
 

--- a/workers/src/routes/apikeys.ts
+++ b/workers/src/routes/apikeys.ts
@@ -1,21 +1,36 @@
 import type { Context } from 'hono';
 import type { Env } from '../types';
 
+const KEY_TTL_DAYS = 30;
+
 function maskKey(keyValue: string): string {
   return keyValue.slice(0, 5) + '••••' + keyValue.slice(-4);
 }
 
+function expiresAt(createdAt: string): string {
+  // Handle both ISO (with Z/timezone) and SQLite datetime format (no timezone, assume UTC)
+  const d = new Date(createdAt.includes('T') ? createdAt : createdAt + 'Z');
+  d.setDate(d.getDate() + KEY_TTL_DAYS);
+  return d.toISOString();
+}
+
 export async function listAPIKeys(c: Context<{ Bindings: Env }>) {
   const deviceId = c.req.header('X-Device-ID')!;
+  // Only return non-expired keys
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - KEY_TTL_DAYS);
   const { results } = await c.env.DB.prepare(
-    'SELECT id, label, key_value, created_at FROM api_keys WHERE device_id = ? ORDER BY created_at DESC'
-  ).bind(deviceId).all();
+    `SELECT id, label, key_value, created_at FROM api_keys
+     WHERE device_id = ? AND created_at > ?
+     ORDER BY created_at DESC`
+  ).bind(deviceId, cutoff.toISOString()).all();
 
   const keys = (results as { id: string; label: string | null; key_value: string; created_at: string }[]).map(r => ({
     id: r.id,
     label: r.label,
     key_hint: maskKey(r.key_value),
     created_at: r.created_at,
+    expires_at: expiresAt(r.created_at),
   }));
   return c.json({ keys, count: keys.length });
 }
@@ -30,18 +45,24 @@ export async function createAPIKey(c: Context<{ Bindings: Env }>) {
   const keyValue = 'robo_' + [...crypto.getRandomValues(new Uint8Array(16))]
     .map(b => b.toString(16).padStart(2, '0')).join('');
 
-  // Atomic insert — only succeeds if device has fewer than 3 keys
+  // Compute cutoff date for expiry check
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - KEY_TTL_DAYS);
+  const cutoffISO = cutoff.toISOString();
+
+  // Atomic insert — only succeeds if device has fewer than 3 non-expired keys
   const result = await c.env.DB.prepare(
     `INSERT INTO api_keys (id, device_id, key_value, label)
      SELECT ?, ?, ?, ?
-     WHERE (SELECT COUNT(*) FROM api_keys WHERE device_id = ?) < 3`
-  ).bind(id, deviceId, keyValue, label, deviceId).run();
+     WHERE (SELECT COUNT(*) FROM api_keys WHERE device_id = ? AND created_at > ?) < 3`
+  ).bind(id, deviceId, keyValue, label, deviceId, cutoffISO).run();
 
   if (!result.meta.changes) {
     return c.json({ error: 'Maximum 3 API keys per device' }, 400);
   }
 
-  return c.json({ id, key_value: keyValue, label, created_at: new Date().toISOString() }, 201);
+  const createdAt = new Date().toISOString();
+  return c.json({ id, key_value: keyValue, label, created_at: createdAt, expires_at: expiresAt(createdAt) }, 201);
 }
 
 export async function deleteAPIKey(c: Context<{ Bindings: Env }>) {


### PR DESCRIPTION
## Summary
- **Keychain storage**: Device credentials (ID + MCP token) now persist in Keychain, surviving app reinstalls. Existing UserDefaults credentials auto-migrate.
- **30-day API key expiry**: Backend filters out expired keys; create response includes `expires_at`. UI shows countdown with orange warning at ≤7 days.
- **Tests + D1 fix**: 8 vitest tests for API key routes, fixed missing `api_keys` table in D1.

## Test plan
- [ ] Delete and reinstall app — device should retain same ID/token
- [ ] Create API key — verify "Expires in 30 days" shown
- [ ] Open Developer Portal with no keys — should show "No API keys yet" (no error)
- [ ] `cd workers && npm test` — 8 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)