### PR TITLE
docs: mandatory worktree rules for multi-agent dev

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,17 @@ Agents are defined in `ios/Robo/Services/MockAgentService.swift` and skills in `
 - **Storage:** R2 (object storage)
 - **Language:** TypeScript 5+
 
+## Multi-Agent Development Rules
+
+**Multiple AI agents work on this repo simultaneously. This is mandatory, not optional.**
+
+1. **ALWAYS use a git worktree** for ALL work: `git worktree add /tmp/robo-<feature> -b feat/<feature> main`
+2. **NEVER edit files in the main worktree** (`/Users/m/gh/hackathon-cc-2026/robo/`) — another agent may be using it
+3. **NEVER commit or push directly to main** — always create a PR from your feature branch
+4. **NEVER deploy the backend (`wrangler deploy`) from a feature branch** — only deploy from `main` after merge
+5. **Build in your worktree**: `cd /tmp/robo-<feature>/ios && xcodegen generate && xcodebuild ...`
+6. **Clean up worktrees** when done: `git worktree remove /tmp/robo-<feature>`
+
 ## Coding Conventions
 
 ### Swift Style


### PR DESCRIPTION
## Summary
- Adds explicit Multi-Agent Development Rules section to CLAUDE.md
- Makes git worktree usage mandatory for all AI agents working on the repo
- Prevents direct commits to main and edits in the main worktree

## Test plan
- [ ] Verify CLAUDE.md renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)