### PR TITLE
feat: schema V10 + disable Coindex tool

### DIFF
--- a/ios/Robo/Models/RoboSchema.swift
+++ b/ios/Robo/Models/RoboSchema.swift
@@ -614,18 +614,75 @@ enum RoboSchemaV9: VersionedSchema {
     }
 }
 
+// MARK: - Schema V10 (external upload tracking on agent completions)
+
+enum RoboSchemaV10: VersionedSchema {
+    static var versionIdentifier = Schema.Version(10, 0, 0)
+
+    static var models: [any PersistentModel.Type] {
+        [ScanRecord.self, RoomScanRecord.self, MotionRecord.self,
+         AgentCompletionRecord.self, ProductCaptureRecord.self,
+         BeaconEventRecord.self, HealthRecord.self]
+    }
+
+    // Re-export V9 models unchanged
+    typealias ScanRecord = RoboSchemaV4.ScanRecord
+    typealias RoomScanRecord = RoboSchemaV9.RoomScanRecord
+    typealias MotionRecord = RoboSchemaV4.MotionRecord
+    typealias ProductCaptureRecord = RoboSchemaV6.ProductCaptureRecord
+    typealias BeaconEventRecord = RoboSchemaV7.BeaconEventRecord
+    typealias HealthRecord = RoboSchemaV8.HealthRecord
+
+    @Model
+    final class AgentCompletionRecord {
+        var agentId: String
+        var agentName: String
+        var requestId: String
+        var skillType: String
+        var itemCount: Int
+        var completedAt: Date
+
+        // V10: External service URL and photo filenames for upload tracking
+        var albumURL: String?
+        var photoFilenamesJSON: String?
+
+        init(
+            agentId: String,
+            agentName: String,
+            requestId: String,
+            skillType: String,
+            itemCount: Int
+        ) {
+            self.agentId = agentId
+            self.agentName = agentName
+            self.requestId = requestId
+            self.skillType = skillType
+            self.itemCount = itemCount
+            self.completedAt = Date()
+        }
+
+        var photoFilenames: [String] {
+            guard let json = photoFilenamesJSON,
+                  let data = json.data(using: .utf8) else { return [] }
+            return (try? JSONDecoder().decode([String].self, from: data)) ?? []
+        }
+    }
+}
+
 // MARK: - Migration Plan
 
 enum RoboMigrationPlan: SchemaMigrationPlan {
     static var schemas: [any VersionedSchema.Type] {
         [RoboSchemaV1.self, RoboSchemaV2.self, RoboSchemaV3.self,
          RoboSchemaV4.self, RoboSchemaV5.self, RoboSchemaV6.self,
-         RoboSchemaV7.self, RoboSchemaV8.self, RoboSchemaV9.self]
+         RoboSchemaV7.self, RoboSchemaV8.self, RoboSchemaV9.self,
+         RoboSchemaV10.self]
     }
 
     static var stages: [MigrationStage] {
         [migrateV1toV2, migrateV2toV3, migrateV3toV4, migrateV4toV5,
-         migrateV5toV6, migrateV6toV7, migrateV7toV8, migrateV8toV9]
+         migrateV5toV6, migrateV6toV7, migrateV7toV8, migrateV8toV9,
+         migrateV9toV10]
     }
 
     static let migrateV1toV2 = MigrationStage.lightweight(
@@ -667,14 +724,19 @@ enum RoboMigrationPlan: SchemaMigrationPlan {
         fromVersion: RoboSchemaV8.self,
         toVersion: RoboSchemaV9.self
     )
+
+    static let migrateV9toV10 = MigrationStage.lightweight(
+        fromVersion: RoboSchemaV9.self,
+        toVersion: RoboSchemaV10.self
+    )
 }
 
 // MARK: - Type Aliases (so the rest of the app uses simple names)
 
-typealias ScanRecord = RoboSchemaV9.ScanRecord
-typealias RoomScanRecord = RoboSchemaV9.RoomScanRecord
-typealias MotionRecord = RoboSchemaV9.MotionRecord
-typealias AgentCompletionRecord = RoboSchemaV9.AgentCompletionRecord
-typealias ProductCaptureRecord = RoboSchemaV9.ProductCaptureRecord
-typealias BeaconEventRecord = RoboSchemaV9.BeaconEventRecord
-typealias HealthRecord = RoboSchemaV9.HealthRecord
+typealias ScanRecord = RoboSchemaV10.ScanRecord
+typealias RoomScanRecord = RoboSchemaV10.RoomScanRecord
+typealias MotionRecord = RoboSchemaV10.MotionRecord
+typealias AgentCompletionRecord = RoboSchemaV10.AgentCompletionRecord
+typealias ProductCaptureRecord = RoboSchemaV10.ProductCaptureRecord
+typealias BeaconEventRecord = RoboSchemaV10.BeaconEventRecord
+typealias HealthRecord = RoboSchemaV10.HealthRecord

--- a/ios/Robo/RoboApp.swift
+++ b/ios/Robo/RoboApp.swift
@@ -24,7 +24,7 @@ struct RoboApp: App {
     /// Attempts to create a ModelContainer with migration, falling back to a
     /// backup-and-recreate strategy. NEVER deletes the store without backing up first.
     private static func createResilientContainer() -> ModelContainer {
-        let schema = Schema(versionedSchema: RoboSchemaV9.self)
+        let schema = Schema(versionedSchema: RoboSchemaV10.self)
         let config = ModelConfiguration(schema: schema)
 
         // Attempt 1: Normal migration

--- a/ios/Robo/Services/ChatService.swift
+++ b/ios/Robo/Services/ChatService.swift
@@ -53,9 +53,10 @@ class ChatService {
             tools.append(ScanRoomTool(captureCoordinator: captureCoordinator))
             tools.append(ScanBarcodeTool(captureCoordinator: captureCoordinator))
             tools.append(TakePhotoTool(captureCoordinator: captureCoordinator))
-            if let coindexService {
-                tools.append(UploadCoinsToCoindexTool(coindexService: coindexService, captureCoordinator: captureCoordinator))
-            }
+            // Coindex upload disabled — see GitHub issue #167 for reactivation plan
+            // if let coindexService {
+            //     tools.append(UploadCoinsToCoindexTool(coindexService: coindexService, captureCoordinator: captureCoordinator))
+            // }
         }
 
         if tools.isEmpty {
@@ -199,9 +200,6 @@ class ChatService {
         - take_photo: Launches the camera to capture photos. Use when user says "take a photo", \
         "photograph my desk", "capture the label", etc.
         - create_availability_poll: Creates a group availability poll with shareable links.
-        - upload_coins_to_coindex: Uploads coin photos to the user's Coindex (coindex.app) collection. \
-        Use when user says "upload coins to coindex", "add to my collection", "send coins to coindex", etc. \
-        Handles OAuth login, photo capture, EXIF stripping, and upload automatically.
 
         When the user asks to scan, photograph, or capture something, call the appropriate tool \
         immediately. Do NOT tell them to go to the Capture tab — you can do it directly.


### PR DESCRIPTION
## Summary
- Add SwiftData V10 schema with `albumURL` and `photoFilenamesJSON` on `AgentCompletionRecord` — general-purpose fields for any agent that uploads to external services
- Update `RoboApp.swift` to reference V10 schema
- Disable Coindex tool registration and system prompt in `ChatService` (see #167 for reactivation plan)

## Test plan
- [ ] Build succeeds (`xcodebuild -scheme Robo`)
- [ ] Existing data migrates cleanly (V9 → V10 lightweight migration)
- [ ] Chat still works — scan room, barcode, photo, group poll all functional
- [ ] No Coindex references visible to end user

🤖 Generated with [Claude Code](https://claude.com/claude-code)