### PR TITLE
feat: Screenshot to AI guide card in Capture grid

### DIFF
--- a/ios/Robo/Views/CaptureHomeView.swift
+++ b/ios/Robo/Views/CaptureHomeView.swift
@@ -165,6 +165,27 @@ struct CaptureHomeView: View {
             CaptureButton(icon: "heart.fill", label: "Health\nData", color: .pink) {
                 showingHealthCapture = true
             }
+
+            NavigationLink {
+                ShareScreenshotGuideView()
+            } label: {
+                VStack(spacing: 12) {
+                    Image(systemName: "square.and.arrow.up")
+                        .font(.system(size: 32))
+                        .foregroundStyle(.cyan)
+
+                    Text("Screenshot\nto AI")
+                        .font(.subheadline.weight(.medium))
+                        .foregroundStyle(.primary)
+                        .multilineTextAlignment(.center)
+                        .lineLimit(2)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .frame(maxWidth: .infinity)
+                .frame(height: 120)
+                .background(Color.cyan.opacity(0.1))
+                .clipShape(RoundedRectangle(cornerRadius: 16))
+            }
         }
     }
 

--- a/ios/Robo/Views/ShareScreenshotGuideView.swift
+++ b/ios/Robo/Views/ShareScreenshotGuideView.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+
+struct ShareScreenshotGuideView: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var showingAlert = false
+
+    var body: some View {
+        VStack(spacing: 32) {
+            Spacer()
+
+            Image(systemName: "square.and.arrow.up")
+                .font(.system(size: 56))
+                .foregroundStyle(.cyan)
+
+            Text("Screenshot to AI")
+                .font(.title.bold())
+
+            VStack(alignment: .leading, spacing: 16) {
+                tipRow(number: "1.circle.fill", icon: "camera.viewfinder", text: "Take a screenshot — press Side + Volume Up")
+                tipRow(number: "2.circle.fill", icon: "square.and.arrow.up", text: "Tap the preview, then tap Share → Robo")
+                tipRow(number: "3.circle.fill", icon: "sparkles", text: "Claude Code sees it via get_screenshot MCP tool")
+            }
+            .padding(.horizontal, 32)
+
+            Spacer()
+
+            Button {
+                showingAlert = true
+            } label: {
+                Text("Try It Now")
+                    .font(.headline)
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(.cyan)
+                    .foregroundStyle(.white)
+                    .clipShape(RoundedRectangle(cornerRadius: 14))
+            }
+            .padding(.horizontal, 40)
+            .padding(.bottom, 40)
+        }
+        .alert("Ready?", isPresented: $showingAlert) {
+            Button("Got It") { dismiss() }
+        } message: {
+            Text("Take a screenshot now, then tap Share → Robo")
+        }
+        .navigationTitle("Screenshot to AI")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private func tipRow(number: String, icon: String, text: String) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: number)
+                .font(.title3)
+                .foregroundStyle(.cyan)
+                .frame(width: 28)
+            Image(systemName: icon)
+                .font(.title3)
+                .foregroundStyle(.secondary)
+                .frame(width: 28)
+            Text(text)
+                .font(.body)
+                .foregroundStyle(.primary)
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        ShareScreenshotGuideView()
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `ShareScreenshotGuideView.swift` — 3-step instructional view showing how to share screenshots to AI
- Adds cyan "Screenshot to AI" card to the Capture grid in `CaptureHomeView.swift`

## Test plan
- [ ] Open Capture tab → verify new cyan "Screenshot to AI" card appears
- [ ] Tap card → verify 3-step guide view opens
- [ ] Verify back navigation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)