### PR TITLE
fix: idempotent device registration via vendor_id

### DIFF
--- a/ios/Robo/Services/APIService.swift
+++ b/ios/Robo/Services/APIService.swift
@@ -41,9 +41,11 @@ class APIService {
 
     // MARK: - Device Registration
 
-    func registerDevice(name: String) async throws -> DeviceConfig {
+    func registerDevice(name: String, vendorId: String?, regenerateToken: Bool = false) async throws -> DeviceConfig {
         let url = try makeURL(path: "/api/devices/register")
-        let payload = ["name": name]
+        var payload: [String: Any] = ["name": name]
+        if let vendorId { payload["vendor_id"] = vendorId }
+        if regenerateToken { payload["regenerate_token"] = true }
 
         let response: RegisterResponse = try await post(url: url, body: payload)
         return DeviceConfig(

--- a/ios/RoboTests/DeviceServiceTests.swift
+++ b/ios/RoboTests/DeviceServiceTests.swift
@@ -6,7 +6,7 @@ import Testing
 private struct MockRegistrar: DeviceRegistering {
     var result: Result<DeviceConfig, Error>
 
-    func registerDevice(name: String) async throws -> DeviceConfig {
+    func registerDevice(name: String, vendorId: String?, regenerateToken: Bool) async throws -> DeviceConfig {
         try result.get()
     }
 }

--- a/workers/migrations/0008_vendor_id.sql
+++ b/workers/migrations/0008_vendor_id.sql
@@ -1,0 +1,7 @@
+-- Migration: Add vendor_id for idempotent device registration
+-- vendor_id = UIDevice.identifierForVendor (persists across app updates)
+-- Used to dedup device registrations from the same physical phone
+
+ALTER TABLE devices ADD COLUMN vendor_id TEXT;
+
+CREATE UNIQUE INDEX idx_devices_vendor_id ON devices(vendor_id) WHERE vendor_id IS NOT NULL;

--- a/workers/src/types.ts
+++ b/workers/src/types.ts
@@ -38,6 +38,8 @@ export type NutritionLookupResponse = {
 // Request schemas
 export const RegisterDeviceSchema = z.object({
   name: z.string().min(1).max(100),
+  vendor_id: z.string().uuid().optional(),
+  regenerate_token: z.boolean().optional(),
 });
 
 export const SensorDataSchema = z.object({


### PR DESCRIPTION
## Summary
- Adds `vendor_id` column to devices table (D1 migration 0008)
- `POST /api/devices/register` now accepts `vendor_id` (UIDevice.identifierForVendor) — if a device with that vendor_id exists, returns the existing record instead of creating a new one
- Re-register regenerates MCP token on the **same device row** instead of creating a new device
- iOS sends `identifierForVendor` on every registration call

## What this fixes
One iPhone created **19 device registrations** in 6 days. Every TestFlight update lost the device identity, breaking MCP connections and screenshot history. Now the same phone always gets the same device ID back.

## Test plan
- [ ] Deploy migration `0008_vendor_id.sql` to D1
- [ ] Deploy workers
- [ ] Install on device — verify it registers with existing device ID (if previously registered) or creates new one
- [ ] Force-quit and relaunch — verify same device ID returned (idempotent)
- [ ] Re-register in Settings — verify same device ID, new MCP token
- [ ] Verify MCP connection works after re-register

## Post-Deploy Monitoring & Validation
- **What to monitor**: `wrangler d1 execute robo-db --command "SELECT id, vendor_id, registered_at FROM devices ORDER BY registered_at DESC LIMIT 10"`
- **Expected healthy behavior**: New registrations from same phone reuse existing device ID; vendor_id populated
- **Failure signal**: Multiple device rows with same vendor_id (unique index should prevent this)
- **Validation window**: Next TestFlight build install

Closes #183

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)