### PR TITLE
docs: Add MCP setup docs and feature plans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Claude Code MCP config (contains API tokens)
+.mcp.json
+
 # Xcode
 *.xcodeproj
 *.xcworkspace

--- a/docs/cloudflare-resources.md
+++ b/docs/cloudflare-resources.md
@@ -66,6 +66,15 @@
 | `0001_initial_schema.sql` | devices, sensor_data, inbox_cards | Core tables |
 | `0002_hits.sql` | hits, hit_photos | HIT system tables |
 
+## GitHub Actions API Token (`CLOUDFLARE_API_TOKEN`)
+
+Token name: **Robo.app API token**
+
+| Scope | Permissions |
+|-------|-------------|
+| All accounts | D1:Edit, Cloudflare Pages:Edit, Workers R2 Storage:Edit, Workers Scripts:Edit |
+| robo.app zone | Workers Routes:Edit |
+
 ## Wrangler Commands
 
 ```bash

--- a/docs/plans/2026-02-15-feat-hackathon-demo-video-production-plan.md
+++ b/docs/plans/2026-02-15-feat-hackathon-demo-video-production-plan.md
@@ -1,0 +1,211 @@
+---
+title: "Hackathon Demo Video Production"
+type: feat
+status: active
+date: 2026-02-15
+deadline: 2026-02-16 3:00 PM EST
+---
+
+# Hackathon Demo Video Production
+
+## Overview
+
+Create the required 3-minute demo video for the Claude Code hackathon submission. Demo Quality is **30% of judging** — the highest-weighted criterion. The video must show a working demo that "holds up when watched" and is "genuinely cool to experience."
+
+**Submission requirements** (from `docs/feb-10-kickoff-instructions.md`):
+1. 3-minute demo video (YouTube/Loom)
+2. GitHub repo (ready — open source)
+3. 100-200 word written summary
+
+## Production Philosophy: Audio-First
+
+**Start with the voiceover, align everything else to it.** ElevenLabs timing is hard to manipulate after generation, so the audio track is the timeline source of truth. All video segments get trimmed/sped to match.
+
+## Tool Stack
+
+| Tool | Purpose | Cost |
+|------|---------|------|
+| **ElevenLabs** | Voiceover narration | ~$0.30 (have API key) |
+| **Kling 2.6 Pro via Fal.ai** | AI-generated intro/outro video | ~$1-2 (5-10s clips) |
+| **Screen Studio** | iOS app demo recording (device mirroring) | One-time license |
+| **FFmpeg** | Stitch segments, add audio, normalize | Free |
+| **Claude** | Script writing, FFmpeg commands, editing guidance | Already using |
+
+## Video Structure (3 minutes)
+
+Based on `docs/solutions/pitch-storytelling-playbook.md`:
+
+| Beat | Duration | Content | Source |
+|------|----------|---------|--------|
+| **Intro** | ~5s | Cinematic AI-generated title sequence | Kling via Fal.ai |
+| **Beat 1: The Problem** | 30s | "Building an AI agent is easy. Getting it LiDAR data? Months of Swift..." | Screen recording of Xcode/complexity OR text cards |
+| **Beat 2: The Solution** | 15s | "Robo is an open-source iOS app that unlocks native context for any AI agent" | App icon + integration options graphic |
+| **Beat 3: Live Demo** | 90s | Full LiDAR scan walkthrough on real device | Screen Studio (iPhone mirror) |
+| **Beat 4: The Wow** | 30s | "That LiDAR scan just went into Claude. Try doing that without Robo." | Show Claude analyzing the scan data |
+| **Beat 5: Close** | 15s | "Open source. Free tier. $85 of Claude API usage. That's the whole app." | Text cards + GitHub link |
+| **Outro** | ~5s | Logo/URL end card | Kling via Fal.ai OR static |
+
+## Step-by-Step Production Checklist
+
+### Phase 1: Script & Audio (Do First)
+
+- [ ] **Write the full narration script** (~400 words for 3 min at natural pace)
+  - Use key phrases from pitch playbook (see below)
+  - Write conversationally — avoid jargon
+  - Add `<break time="1.0s"/>` tags for pauses between beats
+  - Save as `docs/video/script.md`
+
+- [ ] **Generate voiceover with ElevenLabs**
+  - Model: `eleven_multilingual_v2`
+  - Format: `mp3_44100_128`
+  - Use `seed` parameter for reproducibility
+  - Use `speed: 1.0` (adjust if too fast/slow)
+  - Generate full narration as single file OR per-beat segments
+  - Save to `demo/audio/voiceover.mp3`
+
+- [ ] **Measure audio timing**
+  ```bash
+  ffprobe -i demo/audio/voiceover.mp3 -show_entries format=duration -v quiet -of csv="p=0"
+  ```
+  - Note timestamp for each beat transition
+  - This becomes the master timeline
+
+### Phase 2: Visual Assets (Parallel — order doesn't matter)
+
+- [ ] **Generate intro video with Kling AI (Fal.ai)**
+  - Endpoint: `fal-ai/kling-video/v2.6/pro/text-to-video`
+  - Duration: 5 seconds, 16:9, with audio
+  - Prompt example: "A sleek iPhone floating in space with holographic sensor icons (LiDAR grid, barcode, camera lens) materializing around it. Cinematic lighting, dark background, subtle particle effects. Futuristic, clean, professional."
+  - Export as MP4
+  - Save to `demo/video/intro.mp4`
+
+- [ ] **Generate outro video or static end card**
+  - Options: Kling 5s clip OR simple text card via FFmpeg
+  - Include: robo.app URL, GitHub link, "Built with Claude Code"
+  - Save to `demo/video/outro.mp4`
+
+- [ ] **Record app demo with Screen Studio**
+  - Connect iPhone via wireless mirroring
+  - Record the full flow: Create → LiDAR Scanner → Tips → Scan → Review → Share
+  - Enable auto-zoom on taps
+  - Record ~2-3 minutes raw, will trim to 90s
+  - **Practice the walkthrough 2-3 times before recording**
+  - Save raw to `demo/video/demo_raw.mp4`
+
+- [ ] **Record/capture the "Wow" segment**
+  - Show Claude Code or Claude chat receiving the LiDAR JSON
+  - Show Claude analyzing room dimensions, suggesting furniture placement
+  - Screen record this interaction
+  - Save to `demo/video/wow_segment.mp4`
+
+- [ ] **Create "Problem" visual** (optional: can be just voiceover + text)
+  - Options: Screen recording of Xcode complexity, or simple text cards
+  - Keep minimal — the voiceover carries this beat
+
+### Phase 3: Assembly (After audio + all video ready)
+
+- [ ] **Trim all video segments to match voiceover timing**
+  - Use Screen Studio or FFmpeg to trim demo to ~90s
+  - Speed up if needed (1.1-1.2x max to stay natural)
+  ```bash
+  # Speed up video by 1.15x
+  ffmpeg -i demo_raw.mp4 -filter:v "setpts=0.87*PTS" -filter:a "atempo=1.15" demo_trimmed.mp4
+  ```
+
+- [ ] **Normalize all video specs** (resolution, codec)
+  ```bash
+  # Normalize to 1080p H.264
+  ffmpeg -i input.mp4 -vf "scale=1920:1080:force_original_aspect_ratio=decrease,pad=1920:1080:-1:-1" \
+    -c:v libx264 -crf 18 -c:a aac normalized.mp4
+  ```
+
+- [ ] **Create concat list and stitch**
+  ```bash
+  cat > demo/input.txt << EOF
+  file 'video/intro.mp4'
+  file 'video/problem_segment.mp4'
+  file 'video/demo_trimmed.mp4'
+  file 'video/wow_segment.mp4'
+  file 'video/outro.mp4'
+  EOF
+
+  ffmpeg -f concat -safe 0 -i demo/input.txt -c:v libx264 -c:a aac demo/stitched.mp4
+  ```
+
+- [ ] **Add voiceover track**
+  ```bash
+  ffmpeg -i demo/stitched.mp4 -i demo/audio/voiceover.mp3 \
+    -c:v copy -map 0:v -map 1:a -shortest demo/final.mp4
+  ```
+
+- [ ] **Optional: Add background music (low volume)**
+  ```bash
+  ffmpeg -i demo/stitched.mp4 -i demo/audio/music.mp3 -i demo/audio/voiceover.mp3 \
+    -filter_complex "[1:a]volume=0.15[music];[2:a]volume=1.0[voice];[music][voice]amix=inputs=2:duration=first[mixed]" \
+    -c:v copy -map 0:v -map "[mixed]" -c:a aac demo/final.mp4
+  ```
+
+### Phase 4: Polish & Submit
+
+- [ ] **Review final video** — watch it fresh, check:
+  - Audio/video sync
+  - Total duration ≤ 3 minutes
+  - All text readable
+  - Demo flow makes sense without context
+  - "Wow" moment lands
+
+- [ ] **Upload to YouTube** (unlisted)
+  - Title: "Robo — Native Mobile Context for AI Agents"
+  - Description: Include GitHub link + summary
+
+- [ ] **Write 100-200 word summary** for submission
+  - Save as `docs/video/submission-summary.md`
+
+- [ ] **Submit** before Mon Feb 16, 3:00 PM EST
+
+## Key Phrases for Script (Pre-Approved)
+
+From `docs/solutions/pitch-storytelling-playbook.md`:
+- "Native mobile context for AI agents"
+- "Trapped on the device, invisible to AI agents"
+- "No iOS dev, no App Store"
+- "Months of Swift, Xcode, and App Store review"
+- "The missing bridge"
+- "Guided capture — complete data on the first try"
+- "$85 of Claude API usage. That's it."
+
+**Avoid:** "walled garden", jargon-heavy descriptions
+
+## ElevenLabs Quick Reference
+
+```bash
+# Generate voiceover
+http POST https://api.elevenlabs.io/v1/text-to-speech/{voice_id} \
+  xi-api-key:$ELEVENLABS_API_KEY \
+  text="Your script here" \
+  model_id=eleven_multilingual_v2 \
+  output_format=mp3_44100_128 \
+  voice_settings:='{"stability":0.5,"similarity_boost":0.75,"speed":1.0}' \
+  seed:=12345 \
+  --download --output voiceover.mp3 --timeout=30
+```
+
+## Kling AI (Fal.ai) Quick Reference
+
+```bash
+# Generate intro video
+http POST https://queue.fal.run/fal-ai/kling-video/v2.6/pro/text-to-video \
+  Authorization:"Key $FAL_KEY" \
+  prompt="..." \
+  duration:=5 \
+  aspect_ratio=16:9 \
+  generate_audio:=true \
+  --timeout=30
+```
+
+## References
+
+- Hackathon rules: `docs/feb-10-kickoff-instructions.md`
+- Pitch playbook: `docs/solutions/pitch-storytelling-playbook.md`
+- Use cases: `docs/use-cases.md`
+- Judging: Impact 25%, Opus 4.6 Use 25%, Depth 20%, **Demo Quality 30%**

--- a/docs/plans/2026-02-15-feat-hit-management-ui-polish-plan.md
+++ b/docs/plans/2026-02-15-feat-hit-management-ui-polish-plan.md
@@ -1,0 +1,195 @@
+---
+title: "HIT Management UI: Polish & Remaining Features"
+type: feat
+status: active
+date: 2026-02-15
+issue: "#171"
+---
+
+# HIT Management UI: Polish & Remaining Features
+
+## Overview
+
+Complete the HIT management interface with progress indicators, response loading for all types, delete action, empty states, enhanced sharing, and tab badges. All UI work follows existing patterns in `HitListView.swift` and `HitDetailView.swift`.
+
+## Acceptance Criteria
+
+- [x] All HIT types load responses in detail view (not just group_poll/availability)
+- [x] Progress indicator on list cards: "2/4 responded" for group_polls
+- [x] Apple Intelligence summarize button for poll results (iOS 26+ only, graceful fallback)
+- [x] Pull-to-refresh shows inline loading, not full-screen spinner
+- [x] Empty state when 0 responses: "Waiting for responses..."
+- [x] Share sheet includes poll results text (not just URL)
+- [x] Swipe-to-delete on HIT list + delete button in detail view
+- [x] Badge on HITs tab when new responses arrive
+
+## Implementation Plan
+
+### 1. Load responses for all HIT types
+
+**File:** `ios/Robo/Views/HitDetailView.swift`
+
+Currently the detail view only renders responses for `group_poll` and `availability` types. Add a generic response section that renders for `photo` and any other type.
+
+```swift
+// After the existing group_poll/availability sections, add:
+if hit.hit_type != "group_poll" && hit.hit_type != "availability" && !responses.isEmpty {
+    Section("Responses") {
+        ForEach(responses, id: \.id) { response in
+            ResponseRow(response: response)
+        }
+    }
+}
+```
+
+The `fetchHitResponses(hitId:)` API call already exists in `APIService.swift:153`.
+
+### 2. Progress indicator on list cards
+
+**File:** `ios/Robo/Views/HitListView.swift` (HitCard component, ~line 84)
+
+For group_polls, fetch response count and show progress. Two approaches:
+
+**Option A (preferred — backend):** Add `response_count` and `participant_count` to the `GET /api/hits` list endpoint response so no extra API calls are needed per card.
+
+**File:** `workers/src/routes/hits.ts` (~line 248, list endpoint)
+
+```sql
+SELECT h.*,
+  (SELECT COUNT(*) FROM hit_responses WHERE hit_id = h.id) as response_count
+FROM hits h WHERE h.device_id = ?
+```
+
+**iOS side:** Show in HitCard:
+```swift
+if let responseCount = hit.response_count, let total = hit.participant_count {
+    Text("\(responseCount)/\(total) responded")
+        .font(.caption)
+        .foregroundStyle(.secondary)
+}
+```
+
+### 3. Apple Intelligence summarization
+
+**File:** `ios/Robo/Views/HitDetailView.swift`
+
+Add an optional "Summarize" button that uses iOS 26 FoundationModels (already used in `CreateAvailabilityHITTool.swift`).
+
+```swift
+// Guard availability
+if #available(iOS 26, *) {
+    Button("Summarize Results") {
+        await summarizeResults()
+    }
+}
+```
+
+Build the prompt from response data, pass to `LanguageModelSession`. Show result in an expandable section. Graceful no-op on devices without Apple Intelligence.
+
+### 4. Inline pull-to-refresh loading
+
+**File:** `ios/Robo/Views/HitDetailView.swift`
+
+Replace the full-screen `ProgressView("Loading...")` pattern. Use a `@State private var isRefreshing = false` flag and show a small inline indicator instead of replacing content.
+
+```swift
+.refreshable {
+    isRefreshing = true
+    await loadData()
+    isRefreshing = false
+}
+```
+
+Only show full-screen spinner on initial load (`responses.isEmpty && isLoading`).
+
+### 5. Empty state for 0 responses
+
+**File:** `ios/Robo/Views/HitDetailView.swift`
+
+```swift
+if responses.isEmpty && !isLoading {
+    ContentUnavailableView(
+        "Waiting for responses...",
+        systemImage: "clock",
+        description: Text("Share the link and responses will appear here")
+    )
+}
+```
+
+### 6. Share sheet with results text
+
+**File:** `ios/Robo/Views/HitDetailView.swift`
+
+Build a formatted text summary of results and include it in the `ShareLink` or `UIActivityViewController` items alongside the URL.
+
+```swift
+let shareItems: [Any] = [hitURL, formattedResultsText].compactMap { $0 }
+```
+
+### 7. Delete HIT action
+
+**Files:** `ios/Robo/Views/HitListView.swift`, `ios/Robo/Views/HitDetailView.swift`, `ios/Robo/Services/APIService.swift`
+
+**Critical gotcha (from docs/solutions):** Explicit save after delete if using SwiftData. HITs are API-only so this is a network delete.
+
+**Add to APIService:**
+```swift
+func deleteHit(id: String) async throws {
+    // DELETE /api/hits/:id already exists in backend (hits.ts:426)
+    let _: EmptyResponse = try await request(path: "/api/hits/\(id)", method: "DELETE")
+}
+```
+
+**List swipe-to-delete:**
+```swift
+.swipeActions(edge: .trailing) {
+    Button(role: .destructive) {
+        Task { await deleteHit(hit) }
+    } label: {
+        Label("Delete", systemImage: "trash")
+    }
+}
+```
+
+**Detail view:** Add a toolbar button or destructive button at bottom.
+
+### 8. Tab badge for new responses
+
+**File:** `ios/Robo/Views/ContentView.swift`
+
+Add `@State private var hitBadgeCount: Int = 0` and apply `.badge(hitBadgeCount)` to the HITs tab.
+
+Update count when:
+- Push notification arrives for HIT response (`AppDelegate.swift` notification handler)
+- Clear when user visits HITs tab
+
+```swift
+Tab("HITs", systemImage: "link.badge.plus") {
+    HitListView(deepLinkHitId: $deepLinkHitId)
+}
+.badge(hitBadgeCount)
+```
+
+## Design Notes
+
+- Cards: `secondarySystemGroupedBackground` (light/dark)
+- Accent: `#2563EB` / `Color(red: 0.15, green: 0.39, blue: 0.92)`
+- Dates include year: "Thu Feb 20, 2027"
+- Follow existing `StatusPill` component pattern (HitDetailView:514-549)
+
+## Key Files
+
+| File | Changes |
+|------|---------|
+| `ios/Robo/Views/HitListView.swift` | Progress indicator, swipe-to-delete |
+| `ios/Robo/Views/HitDetailView.swift` | All-type responses, empty state, inline refresh, summarize, share, delete |
+| `ios/Robo/Views/ContentView.swift` | Tab badge |
+| `ios/Robo/Services/APIService.swift` | deleteHit method |
+| `workers/src/routes/hits.ts` | response_count in list endpoint |
+
+## References
+
+- Issue: #171
+- PR #170 (base HIT list + detail views)
+- `docs/solutions/database-issues/swiftdata-task-detached-isolation-and-delete-save-reliability-20260210.md` — delete patterns
+- `docs/solutions/integration-issues/cloudflare-multi-service-deployment-hit-system-20260212.md` — deployment checklist

--- a/docs/plans/2026-02-15-feat-ios-share-extension-screenshot-to-agent-plan.md
+++ b/docs/plans/2026-02-15-feat-ios-share-extension-screenshot-to-agent-plan.md
@@ -1,0 +1,281 @@
+---
+title: "feat: iOS Share Extension — Screenshot to Agent"
+type: feat
+status: completed
+date: 2026-02-15
+---
+
+# iOS Share Extension — Screenshot to Agent
+
+## Overview
+
+Add an iOS Share Extension so users can share screenshots directly to their AI agent via the iOS share sheet. User takes a screenshot, taps Share, selects "Robo", and the image is optimized and sent to their connected agent. No need to open the Robo app.
+
+**Core UX:** Screenshot → Share Sheet → "Robo" → optimized image → AI agent
+
+## Problem Statement
+
+Getting a screenshot from your phone to an AI agent today requires: open Robo → navigate to capture → take photo or import from gallery. For quick screenshots (error messages, product labels, UI mockups), this is too many steps. The iOS share sheet is the native, zero-friction path.
+
+## Proposed Solution
+
+A lightweight Share Extension target (`RoboShare`) that:
+
+1. Accepts images from the iOS share sheet
+2. Downsamples to reduce AI context window usage (max 1536px longest edge, JPEG quality 0.7)
+3. Sends the optimized image to the user's primary connected agent via the Robo API
+4. Shows brief success/error feedback, then dismisses
+
+### Architecture
+
+```
+┌─────────────────┐     ┌──────────────────┐     ┌─────────────────┐
+│  iOS Share Sheet │────▸│  RoboShare Ext    │────▸│  Workers API    │
+│  (any app)       │     │  - Downsample     │     │  POST /api/...  │
+│                  │     │  - Read App Group  │     │  - Store in R2  │
+│                  │     │  - Upload JPEG     │     │  - Link to agent│
+└─────────────────┘     └──────────────────┘     └─────────────────┘
+                              │
+                              │ App Group (group.com.silv.Robo)
+                              │ - device_id, agent_id, api_url
+                              ▼
+                        ┌──────────────────┐
+                        │  Robo Main App    │
+                        │  (writes config)  │
+                        └──────────────────┘
+```
+
+### Image Optimization Strategy
+
+**Goal:** Minimize tokens consumed in the AI agent's context window while preserving readability.
+
+| Parameter | Value | Rationale |
+|-----------|-------|-----------|
+| Max dimension | 1536px (longest edge) | Claude/GPT vision sweet spot — readable text, reasonable tokens |
+| JPEG quality | 0.7 | Good balance of size vs. clarity for screenshots |
+| Target file size | ~100-200KB | Typical optimized screenshot |
+| Max file size | 1MB hard limit | Reject if still too large after compression |
+| Method | `CGImageSourceCreateThumbnailAtIndex` | Memory-efficient — no intermediate UIImage allocation |
+
+**Why `CGImageSource` over `UIGraphicsBeginImageContext`:** Share extensions have a 120MB memory limit. `CGImageSource` downsamples directly from the file URL without loading the full-resolution image into memory. This is critical for large screenshots from Pro Max devices (2796x1290, ~8MB uncompressed).
+
+```swift
+func downsample(imageAt url: URL, maxDimension: CGFloat = 1536) -> Data? {
+    let options: [CFString: Any] = [
+        kCGImageSourceCreateThumbnailFromImageAlways: true,
+        kCGImageSourceCreateThumbnailWithTransform: true,
+        kCGImageSourceThumbnailMaxPixelSize: maxDimension
+    ]
+    guard let source = CGImageSourceCreateWithURL(url as CFURL, nil),
+          let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary)
+    else { return nil }
+
+    let uiImage = UIImage(cgImage: cgImage)
+    return uiImage.jpegData(compressionQuality: 0.7)
+}
+```
+
+## Technical Approach
+
+### 1. New Xcode Target via xcodegen
+
+Add `RoboShare` target to `ios/project.yml`:
+
+```yaml
+RoboShare:
+  type: app-extension
+  platform: iOS
+  deploymentTarget: "17.0"
+  sources:
+    - path: RoboShare
+  entitlements:
+    path: RoboShare/RoboShare.entitlements
+    properties:
+      com.apple.security.application-groups:
+        - group.com.silv.Robo
+  settings:
+    base:
+      PRODUCT_BUNDLE_IDENTIFIER: com.silv.Robo.ShareExtension
+      PRODUCT_MODULE_NAME: RoboShare  # CRITICAL: must be unique per target
+      DEVELOPMENT_TEAM: R3Z5CY34Q5
+      INFOPLIST_FILE: RoboShare/Info.plist
+      CODE_SIGN_ENTITLEMENTS: RoboShare/RoboShare.entitlements
+  info:
+    path: RoboShare/Info.plist
+    properties:
+      CFBundleDisplayName: Robo
+      NSExtension:
+        NSExtensionPointIdentifier: com.apple.share-services
+        NSExtensionPrincipalClass: $(PRODUCT_MODULE_NAME).ShareViewController
+        NSExtensionAttributes:
+          NSExtensionActivationRule:
+            NSExtensionActivationSupportsImageWithMaxCount: 1
+```
+
+**Also update main `Robo` target:**
+- Add `com.apple.security.application-groups: [group.com.silv.Robo]` to entitlements
+- Add dependency: `dependencies: [{target: RoboShare, embed: true}]` (Xcode embeds extension in app bundle)
+
+### 2. App Group Shared State
+
+Main app writes agent config to shared `UserDefaults` on launch and after agent changes:
+
+```swift
+// Shared/AppGroupConfig.swift (accessible to both targets)
+struct AppGroupConfig: Codable {
+    let deviceId: String
+    let agentId: String?
+    let agentName: String?
+    let apiBaseURL: String  // e.g., "https://api.robo.app"
+}
+
+extension AppGroupConfig {
+    static let suiteName = "group.com.silv.Robo"
+
+    static func load() -> AppGroupConfig? {
+        guard let data = UserDefaults(suiteName: suiteName)?.data(forKey: "config") else { return nil }
+        return try? JSONDecoder().decode(AppGroupConfig.self, from: data)
+    }
+
+    func save() {
+        guard let data = try? JSONEncoder().encode(self) else { return }
+        UserDefaults(suiteName: Self.suiteName)?.set(data, forKey: "config")
+    }
+}
+```
+
+### 3. Share Extension UI (SwiftUI via UIHostingController)
+
+Minimal UI — show image thumbnail, agent name, send button:
+
+**Files to create:**
+
+- `ios/RoboShare/ShareViewController.swift` — UIViewController host, loads NSExtensionItem
+- `ios/RoboShare/ShareView.swift` — SwiftUI view (thumbnail + agent name + send/cancel)
+- `ios/RoboShare/ImageOptimizer.swift` — CGImageSource downsampling
+- `ios/RoboShare/ShareUploadService.swift` — POST to API
+- `ios/RoboShare/RoboShare.entitlements` — App Groups entitlement
+- `ios/Robo/Shared/AppGroupConfig.swift` — Shared config (both targets)
+
+### 4. Upload Flow
+
+Extension uploads optimized JPEG to existing photo upload infrastructure:
+
+```
+POST /api/hits/{deviceHitId}/upload
+Content-Type: image/jpeg
+Body: <raw JPEG bytes>
+```
+
+Or if we want a dedicated endpoint:
+
+```
+POST /api/captures/screenshot
+Content-Type: multipart/form-data
+X-Device-ID: {deviceId}
+
+image: <JPEG file>
+source: share_extension
+agent_id: {agentId}
+```
+
+**Decision needed:** Reuse HIT photo upload endpoint or create dedicated screenshot endpoint. Leaning toward reuse — less new code.
+
+### 5. TestFlight / CI
+
+The `testflight.yml` workflow needs to handle the new target. Since xcodegen generates both targets from `project.yml`, the existing `xcodebuild archive` command should pick up the extension automatically (it's embedded in the app bundle). No CI changes expected.
+
+## Acceptance Criteria
+
+- [x] Share Extension appears in iOS share sheet when sharing an image
+- [x] Extension name shows "Robo" with the app icon
+- [x] Only activates for images (not URLs, text, PDFs, etc.)
+- [x] Image is downsampled to max 1536px and JPEG compressed before upload
+- [x] Optimized image is sent to the user's primary connected agent
+- [x] Success feedback shown before dismissal (checkmark + agent name)
+- [x] Error shown if: no agent configured, no network, upload fails
+- [ ] "Open Robo" action shown when app not configured
+- [x] Works when main app is backgrounded or not running
+- [ ] Memory stays under 120MB (profile with Instruments)
+- [x] Builds and archives correctly via `xcodegen generate && xcodebuild archive`
+
+## Known Gotchas (from institutional learnings)
+
+1. **`PRODUCT_MODULE_NAME` must be unique** — Set to `RoboShare`, not inherited from project `PRODUCT_NAME: Robo`. Otherwise duplicate `.swiftmodule` build errors. ([docs/solutions/build-errors/xcodegen-test-target-duplicate-swiftmodule-20260210.md](../solutions/build-errors/xcodegen-test-target-duplicate-swiftmodule-20260210.md))
+
+2. **Never edit Info.plist directly** — All keys go in `project.yml` under `info.properties`. xcodegen regenerates Info.plist on every run. ([docs/solutions/build-errors/xcodegen-drops-info-plist-keys-testflight-compliance-20260210.md](../solutions/build-errors/xcodegen-drops-info-plist-keys-testflight-compliance-20260210.md))
+
+3. **Entitlements declared in two places** — Both `project.yml` (under `entitlements.properties`) AND the `.entitlements` plist file. ([docs/solutions/integration-issues/ble-provisioning-wifi-integration-20260214.md](../solutions/integration-issues/ble-provisioning-wifi-integration-20260214.md))
+
+4. **Explicit `modelContext.save()` before dismissal** — If SwiftData is used, autosave races with extension lifecycle. Always call `try modelContext.save()` before `completeRequest()`. ([docs/solutions/database-issues/swiftdata-persistence-failure-no-save-no-schema-versioning-20260210.md](../solutions/database-issues/swiftdata-persistence-failure-no-save-no-schema-versioning-20260210.md))
+
+5. **`NSExtensionActivationRule` must not be `TRUEPREDICATE`** — App Store rejects it. Use specific activation keys like `NSExtensionActivationSupportsImageWithMaxCount: 1`.
+
+6. **120MB memory limit** — Use `CGImageSourceCreateThumbnailAtIndex` for downsampling, never load full-res UIImage.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Agent routing | Always primary agent | MVP simplicity; agent picker in M2 |
+| Image format | JPEG 0.7 quality | Best size/quality for screenshots with text |
+| Max dimension | 1536px longest edge | Claude vision sweet spot |
+| Offline handling | Fail with error message | No queue — extension lifecycle too short for retry |
+| Multi-image | Single image only | `NSExtensionActivationSupportsImageWithMaxCount: 1` |
+| Success feedback | Brief toast ("Sent to AgentName") | User needs confirmation it worked |
+| SwiftData in extension | No — use App Group UserDefaults only | Avoids schema sync complexity, extension only needs device/agent config |
+| Network timeout | 15 seconds | Balance between slow networks and user patience in share sheet |
+
+## Implementation Phases
+
+### Phase 1: Extension Skeleton + Image Optimization
+- Add `RoboShare` target to `project.yml`
+- Create entitlements with App Groups for both targets
+- Implement `ShareViewController` + `ShareView` (SwiftUI)
+- Implement `ImageOptimizer` with CGImageSource downsampling
+- Verify builds with `xcodegen generate && xcodebuild`
+
+### Phase 2: App Group Config + Upload
+- Add `AppGroupConfig` shared struct
+- Main app writes config on launch/agent change
+- Extension reads config and uploads optimized image
+- Wire up to existing API endpoint (or create `/api/captures/screenshot`)
+- Success/error UI
+
+### Phase 3: Polish + TestFlight
+- Test on physical device (extension requires real device)
+- Profile memory with Instruments
+- Verify TestFlight build includes extension
+- Clean stale DerivedData before device install
+
+## File Changes Summary
+
+### New Files
+| File | Purpose |
+|------|---------|
+| `ios/RoboShare/ShareViewController.swift` | Extension entry point, UIHostingController host |
+| `ios/RoboShare/ShareView.swift` | SwiftUI UI (thumbnail, agent name, send/cancel) |
+| `ios/RoboShare/ImageOptimizer.swift` | CGImageSource downsampling + JPEG compression |
+| `ios/RoboShare/ShareUploadService.swift` | URLSession upload to API |
+| `ios/RoboShare/RoboShare.entitlements` | App Groups entitlement |
+| `ios/Robo/Shared/AppGroupConfig.swift` | Shared config struct (both targets read/write) |
+
+### Modified Files
+| File | Change |
+|------|--------|
+| `ios/project.yml` | Add `RoboShare` target, add App Groups to `Robo` entitlements, add embed dependency |
+| `ios/Robo/Robo.entitlements` | Add `com.apple.security.application-groups` |
+| `ios/Robo/RoboApp.swift` (or DeviceService) | Write AppGroupConfig on launch |
+
+### Possibly Modified
+| File | Change |
+|------|--------|
+| `workers/src/routes/` | New endpoint or reuse existing for screenshot upload |
+| `.github/workflows/testflight.yml` | Verify extension is included in archive (likely automatic) |
+
+## References
+
+- [iOS Share Extension with SwiftUI and SwiftData — Sam Merrell](https://www.merrell.dev/ios-share-extension-with-swiftui-and-swiftdata/)
+- [Memory limits in iOS app extensions — Igor Kulman](https://blog.kulman.sk/dealing-with-memory-limits-in-app-extensions/)
+- [Apple: App Extension Programming Guide](https://developer.apple.com/library/archive/documentation/General/Conceptual/ExtensibilityPG/ExtensionScenarios.html)
+- [XcodeGen ProjectSpec](https://github.com/yonaskolb/XcodeGen/blob/master/Docs/ProjectSpec.md)

--- a/docs/plans/2026-02-15-fix-keychain-migration-screenshot-privacy-plan.md
+++ b/docs/plans/2026-02-15-fix-keychain-migration-screenshot-privacy-plan.md
@@ -1,0 +1,153 @@
+---
+title: "fix: Keychain migration backwards compat + screenshot R2 auto-expiry"
+type: fix
+status: active
+date: 2026-02-15
+---
+
+# fix: Keychain migration backwards compat + screenshot R2 auto-expiry
+
+## Overview
+
+Three related issues surfaced after PR #179 (Share Extension):
+
+1. **Keychain migration bug**: Adding `kSecAttrAccessGroup` to `KeychainHelper` made pre-163 keychain entries invisible, causing the app to re-register with a new device ID instead of preserving the existing one. MCP still uses the old device ID → screenshots uploaded by the share extension are invisible to agents.
+2. **No tests for keychain migration**: The migration path (keychain access group change) has no test coverage.
+3. **Screenshot privacy**: Screenshots stored in R2 persist forever. User explicitly doesn't want liability for people's private data on the cloud — screenshots should auto-expire.
+
+## Problem Analysis
+
+### Root Cause: Device ID Mismatch
+
+```
+Before build 163:
+  KeychainHelper.save() → kSecClassGenericPassword (NO access group)
+  KeychainHelper.load() → queries WITHOUT access group → finds entry ✓
+
+After build 163 (PR #179):
+  KeychainHelper.save() → kSecClassGenericPassword + accessGroup "R3Z5CY34Q5.group.com.silv.Robo"
+  KeychainHelper.load() → queries WITH access group → old entry invisible ✗
+  → Falls to UserDefaults → loads config → save() writes NEW keychain entry with access group
+  → BUT if UserDefaults was stale/missing, falls to .default → bootstrap() → NEW device ID
+```
+
+The user's phone went: keychain miss → UserDefaults miss (or stale) → `.default` → `bootstrap()` → new UUID `a6fd7c15`. Meanwhile MCP token in Claude still points to old device `9a9064d9`.
+
+### Fix Strategy
+
+`KeychainHelper.load()` must try **with** access group first, then fall back to **without** access group (same pattern already implemented in `SharedKeychainHelper` in the worktree). If found via legacy path, immediately re-save with the new access group (migrate in place).
+
+## Acceptance Criteria
+
+### Phase 1: Keychain Migration Fix
+- [ ] `KeychainHelper.load()` tries with access group, then without (backwards compat) — `ios/Robo/Services/KeychainHelper.swift`
+- [ ] When legacy entry found, re-save with access group (migrate in place)
+- [ ] Delete legacy entry after successful migration to avoid duplicates
+- [ ] `SharedKeychainHelper.load()` already has fallback (confirmed in worktree) — commit it
+
+### Phase 2: Tests
+- [ ] Add `KeychainMigrationTests.swift` testing:
+  - Legacy keychain entry (no access group) is found and migrated
+  - Device ID is preserved through migration (not re-registered)
+  - Post-migration, entry is readable with access group
+  - Fresh install (no legacy entry) still works
+- [ ] Add test to `DeviceServiceTests.swift`:
+  - `init()` with keychain miss but UserDefaults hit preserves device ID
+  - `init()` with both miss creates default (unregistered)
+
+### Phase 3: Screenshot R2 Auto-Expiry
+- [ ] Add R2 lifecycle rule: prefix `screenshots/` → delete after 7 days
+- [ ] Add cleanup of D1 `sensor_data` rows for expired screenshots (Workers cron or on-read check)
+- [ ] Document: screenshots are transient, not permanent storage
+- [ ] Consider: save screenshot locally on device (app sandbox) if user wants to keep it
+
+## Technical Approach
+
+### KeychainHelper Migration (`ios/Robo/Services/KeychainHelper.swift`)
+
+```swift
+static func load() -> DeviceConfig? {
+    // Try with access group first (build 163+)
+    if let config = query(accessGroup: accessGroup) {
+        return config
+    }
+    // Fallback: try without access group (pre-163 keychain entries)
+    if let config = query(accessGroup: nil) {
+        // Migrate: re-save with access group, delete legacy
+        save(config)
+        deleteLegacy()
+        return config
+    }
+    return nil
+}
+
+private static func query(accessGroup: String?) -> DeviceConfig? {
+    var q: [String: Any] = [
+        kSecClass as String: kSecClassGenericPassword,
+        kSecAttrService as String: service,
+        kSecAttrAccount as String: account,
+        kSecReturnData as String: true,
+        kSecMatchLimit as String: kSecMatchLimitOne,
+    ]
+    if let accessGroup { q[kSecAttrAccessGroup as String] = accessGroup }
+    var result: AnyObject?
+    guard SecItemCopyMatching(q as CFDictionary, &result) == errSecSuccess,
+          let data = result as? Data else { return nil }
+    return try? JSONDecoder().decode(DeviceConfig.self, from: data)
+}
+
+private static func deleteLegacy() {
+    let q: [String: Any] = [
+        kSecClass as String: kSecClassGenericPassword,
+        kSecAttrService as String: service,
+        kSecAttrAccount as String: account,
+        // NO access group — targets legacy entry
+    ]
+    SecItemDelete(q as CFDictionary)
+}
+```
+
+### R2 Lifecycle Rule
+
+Cloudflare R2 supports [object lifecycle rules](https://developers.cloudflare.com/r2/buckets/object-lifecycles/) natively. Configure via wrangler or dashboard:
+
+```bash
+# Via wrangler CLI (or dashboard)
+# Rule: delete objects with prefix "screenshots/" after 7 days
+wrangler r2 bucket lifecycle set robo-data \
+  --rule '{"id":"screenshot-expiry","enabled":true,"conditions":{"prefix":"screenshots/"},"action":{"type":"Delete","afterDays":7}}'
+```
+
+7 days gives enough buffer for:
+- Agent to fetch screenshot via MCP `get_screenshot` tool
+- User to re-share if needed
+- Debugging if something goes wrong
+
+### D1 Cleanup
+
+Add a check in `get_screenshot` MCP tool: if R2 object is gone (expired), return helpful message instead of error. Optionally add a Workers cron to clean up orphaned D1 rows.
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `ios/Robo/Services/KeychainHelper.swift` | Add fallback load without access group, migrate-in-place |
+| `ios/RoboShare/SharedKeychainHelper.swift` | Commit existing fallback changes from worktree |
+| `ios/RoboShare/ShareViewController.swift` | Commit existing debug improvements from worktree |
+| `ios/RoboTests/DeviceServiceTests.swift` | Add keychain migration test scenarios |
+| `workers/src/mcp.ts` | Handle expired R2 screenshots gracefully in `get_screenshot` |
+| R2 bucket config | Add lifecycle rule for `screenshots/` prefix |
+
+## Dependencies & Risks
+
+- **R2 lifecycle rules**: Objects typically removed within 24 hours of expiration — not instant
+- **Keychain migration**: One-time operation per device. If it fails, UserDefaults fallback still works
+- **Device ID mismatch for existing users**: After migration fix, the user's current device (`a6fd7c15`) is the "real" one. Old MCP token (`9a9064d9`) needs to be updated — user should re-register in Settings to get new MCP token pointing to current device
+
+## References
+
+- PR #179: Share Extension implementation
+- `ios/Robo/Services/DeviceService.swift:18-36` — init migration flow
+- `ios/RoboTests/DeviceServiceTests.swift` — existing reRegister tests
+- [Cloudflare R2 Object Lifecycles](https://developers.cloudflare.com/r2/buckets/object-lifecycles/)
+- `docs/solutions/data-migration/PATTERN_SUMMARY.md` — related migration patterns


### PR DESCRIPTION
## Summary
Documentation and planning updates for upcoming features.

## Changes
- `.gitignore`: Exclude `.mcp.json` to prevent committing API tokens
- `cloudflare-resources.md`: Document GitHub Actions API token scopes
- Plans: Hackathon demo video, HIT management UI polish, Share Extension, Keychain migration fix

## Context
Added planning docs for features in flight. The `.mcp.json` exclusion prevents accidental token commits in future dev workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)