### PR TITLE
fix(share): Bearer token auth for Share Extension

### DIFF
--- a/ios/RoboShare/ShareViewController.swift
+++ b/ios/RoboShare/ShareViewController.swift
@@ -139,6 +139,9 @@ class ShareViewController: UIViewController {
         request.httpMethod = "POST"
         request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
         request.setValue(config.id, forHTTPHeaderField: "X-Device-ID")
+        if let token = config.mcpToken {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
         request.timeoutInterval = 15
 
         var body = Data()

--- a/ios/RoboShare/SharedKeychainHelper.swift
+++ b/ios/RoboShare/SharedKeychainHelper.swift
@@ -52,7 +52,9 @@ enum SharedKeychainHelper {
 }
 
 /// Minimal subset of DeviceConfig needed by the share extension.
+/// Fields are decoded from the full DeviceConfig stored by the main app.
 struct SharedDeviceConfig: Codable {
     var id: String
     var apiBaseURL: String
+    var mcpToken: String?
 }

--- a/workers/src/middleware/deviceAuth.ts
+++ b/workers/src/middleware/deviceAuth.ts
@@ -1,8 +1,35 @@
 import { createMiddleware } from 'hono/factory';
 import type { Env } from '../types';
 
+/**
+ * Authenticates requests via X-Device-ID header.
+ * If a Bearer token is also present, resolves the device ID from the token
+ * and stores it in context as 'resolvedDeviceId'. This allows the Share
+ * Extension to use Bearer auth (resilient to stale device IDs in keychain).
+ */
 export const deviceAuth = createMiddleware<{ Bindings: Env }>(async (c, next) => {
-  const deviceId = c.req.header('X-Device-ID');
+  let deviceId = c.req.header('X-Device-ID');
+
+  // If Bearer token is present, resolve the canonical device ID from it.
+  // This takes precedence over X-Device-ID (which may be stale).
+  const authHeader = c.req.header('Authorization');
+  if (authHeader?.startsWith('Bearer ')) {
+    const token = authHeader.slice(7);
+    const tokenDevice = await c.env.DB.prepare(
+      'SELECT id FROM devices WHERE mcp_token = ?'
+    ).bind(token).first<{ id: string }>();
+
+    if (tokenDevice) {
+      c.set('resolvedDeviceId', tokenDevice.id);
+      // If no X-Device-ID header, use the token-resolved ID for backward compat
+      if (!deviceId) {
+        deviceId = tokenDevice.id;
+      }
+      await next();
+      return;
+    }
+    // Invalid token — fall through to X-Device-ID check
+  }
 
   if (!deviceId) {
     return c.json({ error: 'Missing X-Device-ID header' }, 401);
@@ -16,5 +43,6 @@ export const deviceAuth = createMiddleware<{ Bindings: Env }>(async (c, next) =>
     return c.json({ error: 'Unknown device' }, 403);
   }
 
+  c.set('resolvedDeviceId', deviceId);
   await next();
 });

--- a/workers/src/routes/screenshots.ts
+++ b/workers/src/routes/screenshots.ts
@@ -3,11 +3,12 @@ import type { Env } from '../types';
 
 /**
  * POST /api/screenshots — Upload a screenshot image (multipart/form-data)
- * Headers: X-Device-ID (validated by deviceAuth middleware)
+ * Auth: Bearer token (preferred, resolves device ID) or X-Device-ID header
  * Body: multipart with "image" file field
  */
 export async function uploadScreenshot(c: Context<{ Bindings: Env }>) {
-  const deviceId = c.req.header('X-Device-ID')!;
+  // Prefer token-resolved device ID (accurate even if X-Device-ID is stale)
+  const deviceId = c.get('resolvedDeviceId') ?? c.req.header('X-Device-ID')!;
 
   let formData: FormData;
   try {


### PR DESCRIPTION
## Summary
- Share Extension now sends MCP Bearer token alongside X-Device-ID
- `deviceAuth` middleware resolves canonical device ID from Bearer token (takes precedence over potentially stale X-Device-ID)
- Screenshot route uses the token-resolved device ID, ensuring MCP can always find screenshots

## Root Cause
After device re-registration, the Share Extension could read a stale device ID from the shared keychain if the main app hadn't been foregrounded. Screenshots uploaded under the old device ID were invisible to MCP queries.

## Changes
| File | Change |
|------|--------|
| `SharedKeychainHelper.swift` | Added `mcpToken` field to `SharedDeviceConfig` |
| `ShareViewController.swift` | Sends `Authorization: Bearer <token>` header |
| `deviceAuth.ts` | Resolves device ID from Bearer token, stores in context |
| `screenshots.ts` | Uses `resolvedDeviceId` from context |

## Testing
- Build succeeds (iOS + Workers dry-run)
- Backward compatible: X-Device-ID still works if no Bearer token present

## Post-Deploy Monitoring & Validation
- **What to monitor**: Screenshot upload success rate in Workers analytics
- **Validation**: After deploying workers + new TestFlight build, share a screenshot without opening Settings tab first — verify it's retrievable via MCP
- **Failure signal**: 401/403 errors on `/api/screenshots` endpoint
- **No additional operational monitoring required** for the iOS-only changes (keychain read is local)

Closes #191

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)