### PR TITLE
fix(hit): Availability poll UX + OG cards + tap-to-copy

### DIFF
--- a/ios/Robo/Services/APIService.swift
+++ b/ios/Robo/Services/APIService.swift
@@ -116,7 +116,8 @@ class APIService {
         taskDescription: String,
         hitType: String? = nil,
         config: [String: Any]? = nil,
-        groupId: String? = nil
+        groupId: String? = nil,
+        senderName: String? = nil
     ) async throws -> HitCreateResponse {
         let url = try makeURL(path: "/api/hits")
         var payload: [String: Any] = [
@@ -126,6 +127,7 @@ class APIService {
         if let hitType { payload["hit_type"] = hitType }
         if let config { payload["config"] = config }
         if let groupId { payload["group_id"] = groupId }
+        if let senderName { payload["sender_name"] = senderName }
         return try await post(url: url, body: payload)
     }
 

--- a/ios/Robo/Views/ChatView.swift
+++ b/ios/Robo/Views/ChatView.swift
@@ -324,23 +324,55 @@ private struct MessageBubble: View {
     let isStreaming: Bool
 
     private var isUser: Bool { message.role == .user }
+    @State private var showCopied = false
 
     var body: some View {
         HStack {
             if isUser { Spacer(minLength: 60) }
 
-            HStack(alignment: .bottom, spacing: 0) {
-                Text(message.content.isEmpty && isStreaming ? " " : message.content)
-                if isStreaming && !message.content.isEmpty {
-                    TypingCursor()
+            ZStack(alignment: .top) {
+                HStack(alignment: .bottom, spacing: 0) {
+                    Text(message.content.isEmpty && isStreaming ? " " : message.content)
+                    if isStreaming && !message.content.isEmpty {
+                        TypingCursor()
+                    }
+                }
+                .padding(12)
+                .background(isUser ? Color.blue : Color(.systemGray5))
+                .foregroundStyle(isUser ? .white : .primary)
+                .clipShape(RoundedRectangle(cornerRadius: 16))
+
+                if showCopied {
+                    Text("Copied!")
+                        .font(.caption2)
+                        .fontWeight(.semibold)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(.ultraThinMaterial)
+                        .clipShape(Capsule())
+                        .transition(.opacity.combined(with: .scale))
+                        .offset(y: -8)
                 }
             }
-            .padding(12)
-            .background(isUser ? Color.blue : Color(.systemGray5))
-            .foregroundStyle(isUser ? .white : .primary)
-            .clipShape(RoundedRectangle(cornerRadius: 16))
+            .onTapGesture {
+                guard !message.content.isEmpty, !isStreaming else { return }
+                copyMessage()
+            }
+            .onLongPressGesture {
+                guard !message.content.isEmpty else { return }
+                copyMessage()
+            }
 
             if !isUser { Spacer(minLength: 60) }
+        }
+    }
+
+    private func copyMessage() {
+        UIPasteboard.general.string = message.content
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+        withAnimation(.easeInOut(duration: 0.2)) { showCopied = true }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+            withAnimation(.easeInOut(duration: 0.2)) { showCopied = false }
         }
     }
 }

--- a/workers/src/routes/ogImage.ts
+++ b/workers/src/routes/ogImage.ts
@@ -23,7 +23,10 @@ function buildOgLayout(hit: HitData) {
     const config = hit.config ? JSON.parse(hit.config) : {};
     subtitle = config.context || config.title || hit.task_description || '';
   } else if (hit.hit_type === 'availability') {
-    headline = `${senderName} is planning something`;
+    const config = hit.config ? JSON.parse(hit.config) : {};
+    const title = config.title || hit.task_description || 'something';
+    headline = `${senderName} is planning ${title}`;
+    subtitle = '';
   }
 
   if (headline.length > 50) headline = headline.slice(0, 47) + '...';
@@ -40,7 +43,9 @@ function buildOgHtml(headline: string, subtitle: string): string {
     ? `<div style="display: flex; font-size: 24px; color: #3b82f6; background-color: rgba(37,99,235,0.12); border: 1px solid rgba(37,99,235,0.25); border-radius: 12px; padding: 12px 20px; line-height: 1.4;">${safeSubtitle}</div>`
     : '';
 
-  return `<div style="display: flex; width: 1200px; height: 630px; background-color: #06060a; font-family: sans-serif;"><div style="display: flex; flex-direction: column; justify-content: center; padding: 60px 70px; flex: 1;"><div style="display: flex; align-items: center; margin-bottom: 40px;"><div style="display: flex; width: 44px; height: 44px; background-color: #2563EB; border-radius: 12px; margin-right: 12px;"></div><div style="display: flex; font-size: 22px; font-weight: 700; color: #ffffff; letter-spacing: 0.05em;">ROBO.APP</div></div><div style="display: flex; font-size: 52px; font-weight: 700; color: #ffffff; line-height: 1.15; margin-bottom: 20px;">${safeHeadline}</div>${subtitleHtml}<div style="display: flex; font-size: 16px; color: #6b6b7b; margin-top: 40px; letter-spacing: 0.03em;">robo.app</div></div><div style="display: flex; align-items: center; justify-content: center; width: 350px;"><div style="display: flex; width: 200px; height: 200px; background-color: #2563EB; border-radius: 44px;"></div></div></div>`;
+  const robotIcon = `<svg viewBox="0 0 120 120" width="200" height="200" xmlns="http://www.w3.org/2000/svg"><rect width="120" height="120" rx="28" fill="#2563EB"/><circle cx="42" cy="48" r="14" fill="white"/><circle cx="78" cy="48" r="14" fill="white"/><circle cx="42" cy="48" r="7" fill="#1a4fc0"/><circle cx="78" cy="48" r="7" fill="#1a4fc0"/><path d="M 34 80 Q 60 102 86 80" fill="none" stroke="white" stroke-width="8" stroke-linecap="round"/></svg>`;
+
+  return `<div style="display: flex; width: 1200px; height: 630px; background-color: #06060a; font-family: sans-serif;"><div style="display: flex; flex-direction: column; justify-content: center; padding: 60px 70px; flex: 1;"><div style="display: flex; align-items: center; margin-bottom: 40px;"><div style="display: flex; width: 44px; height: 44px; background-color: #2563EB; border-radius: 12px; margin-right: 12px;"></div><div style="display: flex; font-size: 22px; font-weight: 700; color: #ffffff; letter-spacing: 0.05em;">ROBO.APP</div></div><div style="display: flex; font-size: 52px; font-weight: 700; color: #ffffff; line-height: 1.15; margin-bottom: 20px;">${safeHeadline}</div>${subtitleHtml}<div style="display: flex; font-size: 16px; color: #6b6b7b; margin-top: 40px; letter-spacing: 0.03em;">robo.app</div></div><div style="display: flex; align-items: center; justify-content: center; width: 350px;">${robotIcon}</div></div>`;
 }
 
 export async function serveOgImage(c: Context<{ Bindings: Env }>) {

--- a/workers/src/types.ts
+++ b/workers/src/types.ts
@@ -100,6 +100,7 @@ export const CreateHitSchema = z.object({
   hit_type: z.enum(['photo', 'poll', 'availability', 'group_poll']).optional(),
   config: z.record(z.any()).optional(),
   group_id: z.string().max(100).optional(),
+  sender_name: z.string().max(50).optional(),
 });
 
 export const HitResponseSchema = z.object({


### PR DESCRIPTION
## Summary
- **Tap-to-copy** on chat message bubbles (tap or long-press) with haptic feedback and "Copied!" toast
- **Sender name** passed from iOS → API instead of hardcoded "M. Silverman"
- **Date-only grid** when no time slots are specified (no more forced 5-8 PM slots)
- **Military time normalization** — "19:00" → "7 PM" on the web page
- **OG card fixes** — event title in headline ("Matt is planning Movie Night"), robot face SVG icon, no generic subtitle
- **OG meta tags** — availability-specific title/description for iMessage/Slack previews

## Test plan
- [ ] Open Chat, send a message, tap the assistant bubble → should copy text + show "Copied!"
- [ ] Create availability poll via chat → sender should show first name, not "M. Silverman"
- [ ] Create poll without specifying times → web page should show date-only grid
- [ ] Open HIT link in browser → verify OG card shows event title and robot icon
- [ ] Test iMessage link preview for a HIT URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)