### PR TITLE
feat: Add OpenRouter model toggle with CF Worker SSE proxy

### DIFF
--- a/ios/Robo/Models/AIProvider.swift
+++ b/ios/Robo/Models/AIProvider.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+enum AIProvider: String, CaseIterable, Identifiable {
+    case openRouter = "openrouter"
+    case appleOnDevice = "apple"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .openRouter: return "OpenRouter (Cloud)"
+        case .appleOnDevice: return "Apple On-Device"
+        }
+    }
+}

--- a/ios/Robo/Services/APIService.swift
+++ b/ios/Robo/Services/APIService.swift
@@ -31,11 +31,11 @@ class APIService {
         self.deviceService = deviceService
     }
 
-    private var baseURL: String {
+    var baseURL: String {
         deviceService.config.apiBaseURL
     }
 
-    private var deviceId: String {
+    var deviceId: String {
         deviceService.config.id
     }
 

--- a/ios/Robo/Views/SettingsView.swift
+++ b/ios/Robo/Views/SettingsView.swift
@@ -11,6 +11,7 @@ struct SettingsView: View {
     @State private var isReRegistering = false
     @State private var lastMcpCallDate: Date?
     @State private var pollingTask: Task<Void, Never>?
+    @AppStorage("aiProvider") private var aiProviderRaw: String = AIProvider.openRouter.rawValue
     #if DEBUG
     @AppStorage("dev.syncToCloud") private var debugSyncEnabled = false
     @Query(sort: \RoomScanRecord.capturedAt, order: .reverse) private var roomScans: [RoomScanRecord]
@@ -155,6 +156,20 @@ struct SettingsView: View {
                             }
                         }
                     }
+                }
+
+                Section("AI Model") {
+                    Picker("Provider", selection: $aiProviderRaw) {
+                        ForEach(AIProvider.allCases) { provider in
+                            Text(provider.displayName).tag(provider.rawValue)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                    Text(aiProviderRaw == AIProvider.openRouter.rawValue
+                        ? "Uses Gemini Flash Lite via OpenRouter (cloud)"
+                        : "Apple Foundation Models (on-device, iOS 26+)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
 
                 #if DEBUG

--- a/workers/src/index.ts
+++ b/workers/src/index.ts
@@ -16,6 +16,7 @@ import { createHit, getHit, deleteHit, uploadHitPhoto, completeHit, listHits, li
 import { serveHitPage } from './routes/hitPage';
 import { serveOgImage } from './routes/ogImage';
 import { listAPIKeys, createAPIKey, deleteAPIKey } from './routes/apikeys';
+import { chatProxy } from './routes/chat';
 import { deviceAuth } from './middleware/deviceAuth';
 import { mcpTokenAuth } from './middleware/mcpTokenAuth';
 import { handleMcpRequest } from './mcp';
@@ -50,6 +51,9 @@ app.get('/api/nutrition/lookup', deviceAuth, lookupNutrition);
 
 // Opus integration
 app.post('/api/opus/analyze', analyzeWithOpus);
+
+// Chat proxy (OpenRouter) — auth required
+app.post('/api/chat', deviceAuth, chatProxy);
 
 // HIT owner routes (auth required)
 app.post('/api/hits', deviceAuth, createHit);

--- a/workers/src/routes/chat.ts
+++ b/workers/src/routes/chat.ts
@@ -1,0 +1,51 @@
+import type { Context } from 'hono';
+import type { Env } from '../types';
+import { z } from 'zod';
+
+const ChatRequestSchema = z.object({
+  messages: z.array(z.object({
+    role: z.enum(['system', 'user', 'assistant']),
+    content: z.string(),
+  })).min(1),
+  model: z.string().optional(),
+});
+
+const DEFAULT_MODEL = 'google/gemini-2.5-flash-lite-preview-09-2025';
+
+export async function chatProxy(c: Context<{ Bindings: Env }>): Promise<Response> {
+  const body = await c.req.json();
+  const parsed = ChatRequestSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return c.json({ error: 'Invalid request', details: parsed.error.flatten() }, 400);
+  }
+
+  const model = parsed.data.model || c.env.OPENROUTER_MODEL || DEFAULT_MODEL;
+
+  const response = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${c.env.OPENROUTER_API_KEY}`,
+    },
+    body: JSON.stringify({
+      model,
+      messages: parsed.data.messages,
+      stream: true,
+    }),
+  });
+
+  if (!response.ok || !response.body) {
+    const text = await response.text();
+    return c.json({ error: 'OpenRouter request failed', status: response.status, details: text }, 502);
+  }
+
+  // Pass through SSE stream directly — zero buffering
+  return new Response(response.body, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive',
+    },
+  });
+}

--- a/workers/src/types.ts
+++ b/workers/src/types.ts
@@ -10,6 +10,8 @@ export type Env = {
   APNS_AUTH_KEY: string;
   APNS_KEY_ID: string;
   APNS_SANDBOX?: string;
+  OPENROUTER_API_KEY: string;
+  OPENROUTER_MODEL?: string;
 };
 
 // Nutrition lookup


### PR DESCRIPTION
## Summary
- Adds AI Model picker in Settings (OpenRouter cloud default, Apple on-device option)
- New `/api/chat` Worker endpoint proxies SSE stream from OpenRouter with zero buffering
- ChatService routes to OpenRouter or Apple Foundation Models based on user preference
- API key stored as Worker secret (never in iOS binary)
- Default model: `google/gemini-2.5-flash-lite-preview-09-2025`

## Test plan
- [ ] Open Settings → verify AI Model picker shows "OpenRouter (Cloud)" selected
- [ ] Send a chat message → verify streaming response from OpenRouter via Worker
- [ ] Switch to Apple On-Device → verify on-device model still works
- [ ] Switch back to OpenRouter → verify cloud model resumes
- [ ] Deploy Worker (`wrangler deploy`) and verify `/api/chat` endpoint responds

🤖 Generated with [Claude Code](https://claude.com/claude-code)