### PR TITLE
feat: Add reasoning effort low to OpenRouter chat

### DIFF
--- a/workers/src/routes/chat.ts
+++ b/workers/src/routes/chat.ts
@@ -32,6 +32,7 @@ export async function chatProxy(c: Context<{ Bindings: Env }>): Promise<Response
       model,
       messages: parsed.data.messages,
       stream: true,
+      reasoning: { effort: 'low' },
     }),
   });
 


### PR DESCRIPTION
## Summary
- Adds `reasoning: { effort: 'low' }` to OpenRouter chat proxy request

## Test plan
- [ ] Send chat message, verify response still streams correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)