### PR TITLE
feat(onboarding): show only 3 featured skills

### DIFF
--- a/ios/Robo/Generated/FeatureRegistry.swift
+++ b/ios/Robo/Generated/FeatureRegistry.swift
@@ -24,6 +24,7 @@ enum FeatureRegistry {
         let name: String
         let tagline: String
         let status: Status
+        let featured: Bool
         let skillType: AgentRequest.SkillType?
         let category: Category
     }
@@ -40,9 +41,10 @@ enum FeatureRegistry {
     static let skills: [Skill] = [
         Skill(
             id: "lidar",
-            name: "LiDAR Floor Plans",
-            tagline: "3D room scans with Apple RoomPlan",
+            name: "Share Floor Plans with Claude",
+            tagline: "LiDAR room scans you can share with any AI",
             status: .active,
+            featured: true,
             skillType: .lidar,
             category: .sensor
         ),
@@ -51,6 +53,7 @@ enum FeatureRegistry {
             name: "Barcode Scanning",
             tagline: "Instant barcode and QR code capture",
             status: .active,
+            featured: false,
             skillType: .barcode,
             category: .sensor
         ),
@@ -59,6 +62,7 @@ enum FeatureRegistry {
             name: "Guided Photos",
             tagline: "Checklist-driven photo capture for agents",
             status: .active,
+            featured: true,
             skillType: .camera,
             category: .sensor
         ),
@@ -67,6 +71,7 @@ enum FeatureRegistry {
             name: "Product Scanner",
             tagline: "Barcode + photos for product analysis",
             status: .active,
+            featured: true,
             skillType: .productScan,
             category: .workflow
         ),
@@ -75,6 +80,7 @@ enum FeatureRegistry {
             name: "BLE Beacons",
             tagline: "Bluetooth Low Energy beacon detection",
             status: .coming_soon,
+            featured: false,
             skillType: .beacon,
             category: .sensor
         ),
@@ -83,6 +89,7 @@ enum FeatureRegistry {
             name: "HIT Links",
             tagline: "Get data from anyone via shareable links",
             status: .active,
+            featured: false,
             skillType: nil,
             category: .platform
         ),
@@ -91,6 +98,7 @@ enum FeatureRegistry {
             name: "MCP Bridge",
             tagline: "Connect phone sensors to Claude Code",
             status: .active,
+            featured: false,
             skillType: nil,
             category: .platform
         ),
@@ -99,6 +107,7 @@ enum FeatureRegistry {
             name: "Share Screenshot to Claude",
             tagline: "iOS Share Extension for instant context",
             status: .active,
+            featured: false,
             skillType: nil,
             category: .platform
         ),
@@ -107,6 +116,7 @@ enum FeatureRegistry {
             name: "Motion Capture",
             tagline: "Accelerometer and gyroscope data",
             status: .coming_soon,
+            featured: false,
             skillType: .motion,
             category: .sensor
         ),
@@ -115,6 +125,7 @@ enum FeatureRegistry {
             name: "HealthKit Data",
             tagline: "Health and fitness metrics",
             status: .coming_soon,
+            featured: false,
             skillType: .health,
             category: .sensor
         )
@@ -153,6 +164,9 @@ enum FeatureRegistry {
     /// Active skills only.
     static var activeSkills: [Skill] { skills.filter { $0.status == .active } }
 
+    /// Featured skills — shown on onboarding and marketing surfaces.
+    static var featuredSkills: [Skill] { skills.filter { $0.featured } }
+
     /// Coming soon skills only.
     static var comingSoonSkills: [Skill] { skills.filter { $0.status == .coming_soon } }
 
@@ -168,6 +182,7 @@ enum AppCopy {
         static let tagline = "The Context Collector"
         static let ogTitle = "Robo — Phone Sensors as APIs for AI Agents"
         static let ogDescription = "Open-source iOS app that turns your phone's sensors into APIs any AI agent can use. LiDAR, camera, barcodes — no iOS development required."
+        static let description = "Robo collects what they see. Robo helps you share them with your favorite AI agents."
     }
 
     enum Tabs {

--- a/ios/Robo/Views/OnboardingView.swift
+++ b/ios/Robo/Views/OnboardingView.swift
@@ -64,7 +64,7 @@ struct OnboardingView: View {
                         .padding(.bottom, 24)
 
                     // Description
-                    Text("Your phone has incredible sensors. Robo collects what they see — for you, for your team, or for your AI agent.")
+                    Text(AppCopy.App.description)
                         .font(.body)
                         .foregroundStyle(.white.opacity(0.7))
                         .multilineTextAlignment(.center)
@@ -74,7 +74,7 @@ struct OnboardingView: View {
 
                     // Feature pills — driven by FeatureRegistry
                     VStack(spacing: 12) {
-                        ForEach(FeatureRegistry.activeSkills) { skill in
+                        ForEach(FeatureRegistry.featuredSkills) { skill in
                             featureRow(
                                 icon: Self.iconForSkill(skill.id),
                                 text: "\(skill.name) — \(skill.tagline)",

--- a/registry/copy.json
+++ b/registry/copy.json
@@ -3,7 +3,8 @@
     "name": "Robo",
     "tagline": "The Context Collector",
     "og_title": "Robo — Phone Sensors as APIs for AI Agents",
-    "og_description": "Open-source iOS app that turns your phone's sensors into APIs any AI agent can use. LiDAR, camera, barcodes — no iOS development required."
+    "og_description": "Open-source iOS app that turns your phone's sensors into APIs any AI agent can use. LiDAR, camera, barcodes — no iOS development required.",
+    "description": "Robo collects what they see. Robo helps you share them with your favorite AI agents."
   },
   "hero": {
     "headline": "Your phone's sensors,<br>any AI agent.",

--- a/registry/features.json
+++ b/registry/features.json
@@ -2,9 +2,10 @@
   "skills": [
     {
       "id": "lidar",
-      "name": "LiDAR Floor Plans",
-      "tagline": "3D room scans with Apple RoomPlan",
+      "name": "Share Floor Plans with Claude",
+      "tagline": "LiDAR room scans you can share with any AI",
       "status": "active",
+      "featured": true,
       "skillType": "lidar",
       "category": "sensor"
     },
@@ -13,6 +14,7 @@
       "name": "Barcode Scanning",
       "tagline": "Instant barcode and QR code capture",
       "status": "active",
+      "featured": false,
       "skillType": "barcode",
       "category": "sensor"
     },
@@ -21,6 +23,7 @@
       "name": "Guided Photos",
       "tagline": "Checklist-driven photo capture for agents",
       "status": "active",
+      "featured": true,
       "skillType": "camera",
       "category": "sensor"
     },
@@ -29,6 +32,7 @@
       "name": "Product Scanner",
       "tagline": "Barcode + photos for product analysis",
       "status": "active",
+      "featured": true,
       "skillType": "productScan",
       "category": "workflow"
     },
@@ -37,6 +41,7 @@
       "name": "BLE Beacons",
       "tagline": "Bluetooth Low Energy beacon detection",
       "status": "coming_soon",
+      "featured": false,
       "skillType": "beacon",
       "category": "sensor"
     },
@@ -45,6 +50,7 @@
       "name": "HIT Links",
       "tagline": "Get data from anyone via shareable links",
       "status": "active",
+      "featured": false,
       "skillType": null,
       "category": "platform"
     },
@@ -53,6 +59,7 @@
       "name": "MCP Bridge",
       "tagline": "Connect phone sensors to Claude Code",
       "status": "active",
+      "featured": false,
       "skillType": null,
       "category": "platform"
     },
@@ -61,6 +68,7 @@
       "name": "Share Screenshot to Claude",
       "tagline": "iOS Share Extension for instant context",
       "status": "active",
+      "featured": false,
       "skillType": null,
       "category": "platform"
     },
@@ -69,6 +77,7 @@
       "name": "Motion Capture",
       "tagline": "Accelerometer and gyroscope data",
       "status": "coming_soon",
+      "featured": false,
       "skillType": "motion",
       "category": "sensor"
     },
@@ -77,6 +86,7 @@
       "name": "HealthKit Data",
       "tagline": "Health and fitness metrics",
       "status": "coming_soon",
+      "featured": false,
       "skillType": "health",
       "category": "sensor"
     }

--- a/registry/generate.js
+++ b/registry/generate.js
@@ -43,11 +43,13 @@ function generateSwift() {
 
   const skillEntries = skills.map(s => {
     const skillTypeStr = s.skillType ? `.${s.skillType}` : 'nil';
+    const featuredStr = s.featured ? 'true' : 'false';
     return `        Skill(
             id: "${swiftEscape(s.id)}",
             name: "${swiftEscape(s.name)}",
             tagline: "${swiftEscape(s.tagline)}",
             status: .${s.status},
+            featured: ${featuredStr},
             skillType: ${skillTypeStr},
             category: .${s.category}
         )`;
@@ -94,6 +96,7 @@ enum FeatureRegistry {
         let name: String
         let tagline: String
         let status: Status
+        let featured: Bool
         let skillType: AgentRequest.SkillType?
         let category: Category
     }
@@ -121,6 +124,9 @@ ${agentEntries}
     /// Active skills only.
     static var activeSkills: [Skill] { skills.filter { $0.status == .active } }
 
+    /// Featured skills — shown on onboarding and marketing surfaces.
+    static var featuredSkills: [Skill] { skills.filter { $0.featured } }
+
     /// Coming soon skills only.
     static var comingSoonSkills: [Skill] { skills.filter { $0.status == .coming_soon } }
 
@@ -136,6 +142,7 @@ enum AppCopy {
         static let tagline = "${swiftEscape(copy.app.tagline)}"
         static let ogTitle = "${swiftEscape(copy.app.og_title)}"
         static let ogDescription = "${swiftEscape(copy.app.og_description)}"
+        static let description = "${swiftEscape(copy.app.description)}"
     }
 
     enum Tabs {

--- a/workers/src/generated/features.ts
+++ b/workers/src/generated/features.ts
@@ -25,9 +25,10 @@ export interface Agent {
 export const skills: Skill[] = [
   {
     "id": "lidar",
-    "name": "LiDAR Floor Plans",
-    "tagline": "3D room scans with Apple RoomPlan",
+    "name": "Share Floor Plans with Claude",
+    "tagline": "LiDAR room scans you can share with any AI",
     "status": "active",
+    "featured": true,
     "skillType": "lidar",
     "category": "sensor"
   },
@@ -36,6 +37,7 @@ export const skills: Skill[] = [
     "name": "Barcode Scanning",
     "tagline": "Instant barcode and QR code capture",
     "status": "active",
+    "featured": false,
     "skillType": "barcode",
     "category": "sensor"
   },
@@ -44,6 +46,7 @@ export const skills: Skill[] = [
     "name": "Guided Photos",
     "tagline": "Checklist-driven photo capture for agents",
     "status": "active",
+    "featured": true,
     "skillType": "camera",
     "category": "sensor"
   },
@@ -52,6 +55,7 @@ export const skills: Skill[] = [
     "name": "Product Scanner",
     "tagline": "Barcode + photos for product analysis",
     "status": "active",
+    "featured": true,
     "skillType": "productScan",
     "category": "workflow"
   },
@@ -60,6 +64,7 @@ export const skills: Skill[] = [
     "name": "BLE Beacons",
     "tagline": "Bluetooth Low Energy beacon detection",
     "status": "coming_soon",
+    "featured": false,
     "skillType": "beacon",
     "category": "sensor"
   },
@@ -68,6 +73,7 @@ export const skills: Skill[] = [
     "name": "HIT Links",
     "tagline": "Get data from anyone via shareable links",
     "status": "active",
+    "featured": false,
     "skillType": null,
     "category": "platform"
   },
@@ -76,6 +82,7 @@ export const skills: Skill[] = [
     "name": "MCP Bridge",
     "tagline": "Connect phone sensors to Claude Code",
     "status": "active",
+    "featured": false,
     "skillType": null,
     "category": "platform"
   },
@@ -84,6 +91,7 @@ export const skills: Skill[] = [
     "name": "Share Screenshot to Claude",
     "tagline": "iOS Share Extension for instant context",
     "status": "active",
+    "featured": false,
     "skillType": null,
     "category": "platform"
   },
@@ -92,6 +100,7 @@ export const skills: Skill[] = [
     "name": "Motion Capture",
     "tagline": "Accelerometer and gyroscope data",
     "status": "coming_soon",
+    "featured": false,
     "skillType": "motion",
     "category": "sensor"
   },
@@ -100,6 +109,7 @@ export const skills: Skill[] = [
     "name": "HealthKit Data",
     "tagline": "Health and fitness metrics",
     "status": "coming_soon",
+    "featured": false,
     "skillType": "health",
     "category": "sensor"
   }
@@ -141,7 +151,8 @@ export const copy = {
     "name": "Robo",
     "tagline": "The Context Collector",
     "og_title": "Robo — Phone Sensors as APIs for AI Agents",
-    "og_description": "Open-source iOS app that turns your phone's sensors into APIs any AI agent can use. LiDAR, camera, barcodes — no iOS development required."
+    "og_description": "Open-source iOS app that turns your phone's sensors into APIs any AI agent can use. LiDAR, camera, barcodes — no iOS development required.",
+    "description": "Robo collects what they see. Robo helps you share them with your favorite AI agents."
   },
   "hero": {
     "headline": "Your phone's sensors,<br>any AI agent.",


### PR DESCRIPTION
## Summary
- Adds `featured` flag to registry (`features.json`) — LiDAR, Guided Photos, Product Scanner are featured; all others remain active
- Generator now outputs `featured` bool on Swift `Skill` struct + `featuredSkills` computed property
- Adds `AppCopy.App.description` from `copy.json`
- Onboarding uses `featuredSkills` (3 pills) instead of `activeSkills` (8 pills), pushing name input higher
- LiDAR renamed to "Share Floor Plans with Claude" with updated tagline

## Test plan
- [ ] Run `node registry/generate.js` — verify Swift + TS output
- [ ] Build iOS (`xcodegen generate && xcodebuild`)
- [ ] Install on phone — onboarding shows only 3 featured pills
- [ ] Verify name input is higher on screen
- [ ] Verify all capture features still work from main app

🤖 Generated with [Claude Code](https://claude.com/claude-code)