### PR TITLE
feat: HIT card redesign + home screen fixes

### DIFF
--- a/ios/Robo/AppDelegate.swift
+++ b/ios/Robo/AppDelegate.swift
@@ -86,4 +86,5 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
 extension Notification.Name {
     static let hitCompletedNotification = Notification.Name("hitCompletedNotification")
     static let hitResponseNotification = Notification.Name("hitResponseNotification")
+    static let chatPrefillNotification = Notification.Name("chatPrefillNotification")
 }

--- a/ios/Robo/Services/Tools/CreateAvailabilityHITTool.swift
+++ b/ios/Robo/Services/Tools/CreateAvailabilityHITTool.swift
@@ -29,10 +29,17 @@ struct CreateAvailabilityHITTool: Tool {
     let apiService: APIService
 
     func call(arguments: Arguments) async throws -> String {
-        let names = arguments.participants
+        var names = arguments.participants
             .split(separator: ",")
             .map { $0.trimmingCharacters(in: .whitespaces) }
             .filter { !$0.isEmpty }
+
+        // Include the creator as a participant if they have a name set
+        if let creatorName = UserDefaults.standard.string(forKey: "firstName"),
+           !creatorName.isEmpty,
+           !names.contains(where: { $0.localizedCaseInsensitiveCompare(creatorName) == .orderedSame }) {
+            names.insert(creatorName, at: 0)
+        }
 
         let dates = arguments.dateOptions
             .split(separator: ",")

--- a/ios/Robo/Views/CaptureHomeView.swift
+++ b/ios/Robo/Views/CaptureHomeView.swift
@@ -3,8 +3,9 @@ import SwiftData
 import AudioToolbox
 
 struct CaptureHomeView: View {
-    @AppStorage("userName") private var userName = ""
+    @AppStorage("firstName") private var userName = ""
     var switchToMyData: (() -> Void)?
+    var switchToChat: ((String?) -> Void)?
     @Environment(\.modelContext) private var modelContext
     @Query(sort: \RoomScanRecord.capturedAt, order: .reverse) private var roomScans: [RoomScanRecord]
     @Query(sort: \ScanRecord.capturedAt, order: .reverse) private var scans: [ScanRecord]
@@ -125,11 +126,44 @@ struct CaptureHomeView: View {
                 .clipShape(RoundedRectangle(cornerRadius: 12))
             }
 
-            // Interior Designer agent banner (if pending)
+            // HIT link shortcut
+            Button {
+                switchToChat?("Plan a weekend with friends")
+            } label: {
+                HStack(spacing: 12) {
+                    Image(systemName: "link.badge.plus")
+                        .font(.title3)
+                        .foregroundStyle(.indigo)
+                        .frame(width: 36, height: 36)
+                        .background(.indigo.opacity(0.15))
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Plan a Weekend Trip with Friends")
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(.primary)
+                        Text("Use HIT links to send a micro-survey to your group")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+
+                    Spacer()
+
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                }
+                .padding(12)
+                .background(.secondary.opacity(0.1))
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+            }
+
+            // Agent request banners (if pending)
             let pendingAgents = agents.filter { $0.name != "Claude Code" && $0.pendingRequest != nil && $0.status != .syncing }
             if !pendingAgents.isEmpty {
                 HStack {
-                    Text("Agent Requests")
+                    Text("Shortcuts")
                         .font(.headline)
                     Spacer()
                     Text("\(pendingAgents.count)")

--- a/ios/Robo/Views/ContentView.swift
+++ b/ios/Robo/Views/ContentView.swift
@@ -10,7 +10,15 @@ struct ContentView: View {
 
     var body: some View {
         TabView(selection: $selectedTab) {
-            CaptureHomeView(switchToMyData: { selectedTab = 1 })
+            CaptureHomeView(
+                switchToMyData: { selectedTab = 1 },
+                switchToChat: { prefill in
+                    selectedTab = 3
+                    if let prefill {
+                        NotificationCenter.default.post(name: .chatPrefillNotification, object: nil, userInfo: ["message": prefill])
+                    }
+                }
+            )
                 .tabItem {
                     Label(AppStrings.Tabs.capture, systemImage: "sensor.fill")
                 }

--- a/ios/Robo/Views/SafariView.swift
+++ b/ios/Robo/Views/SafariView.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+import SafariServices
+
+struct SafariView: UIViewControllerRepresentable {
+    let url: URL
+
+    func makeUIViewController(context: Context) -> SFSafariViewController {
+        let vc = SFSafariViewController(url: url)
+        vc.preferredControlTintColor = .systemBlue
+        return vc
+    }
+
+    func updateUIViewController(_ uiViewController: SFSafariViewController, context: Context) {}
+}


### PR DESCRIPTION
## Summary
- Fix "Hi, Matt" regression by reading `firstName` key instead of `userName`
- Rename "Agent Requests" → "Shortcuts", add "Plan a Weekend Trip" shortcut that deep-links to Chat
- Redesign HIT result cards: bigger layout with status icon (pending/responded), copy button, and in-app Safari browser
- Include creator (Matt) as first participant in availability polls
- Poll HIT response status when Safari dismisses to show green checkmarks

## Test plan
- [ ] Home screen shows "Hi, Matt" (not "Capture")
- [ ] "Plan a Weekend Trip" shortcut appears and switches to Chat tab
- [ ] In Chat, "Plan a weekend with friends" shows creator in participant list
- [ ] Tap open icon → Safari opens HIT page in-app
- [ ] Fill out form, dismiss Safari → participant row shows green checkmark
- [ ] Tap copy icon → URL copied to clipboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)