### PR TITLE
fix: make TestFlight builds manual-only

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -2,9 +2,6 @@ name: TestFlight
 
 on:
   workflow_dispatch:
-  push:
-    branches: [main]
-    paths: ['ios/**']
 
 concurrency:
   group: testflight-${{ github.ref }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,7 +193,7 @@ wrangler deploy
 ```
 
 ### iOS (TestFlight)
-Auto-deploys to TestFlight on push to `main` when `ios/**` files change (via `.github/workflows/testflight.yml`). Can also trigger manually:
+Manual trigger only (no auto-deploy on push):
 ```bash
 gh workflow run testflight.yml
 ```


### PR DESCRIPTION
## Summary
- Removes auto-trigger on `push to main` for TestFlight workflow
- Builds now only run via `gh workflow run testflight.yml`
- Prevents hitting Apple's daily upload rate limit

## Test plan
- [ ] Verify `gh workflow run testflight.yml` still triggers a build
- [ ] Confirm pushing to main no longer auto-triggers TestFlight