### PR TITLE
feat: Phase 4 — Settings sync API + web settings page

### DIFF
--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -1,29 +1,230 @@
+import { useState, useEffect } from 'react'
 import { useAuth } from '../contexts/AuthContext'
+import { api } from '../lib/api'
+
+type McpToken = {
+  device_id: string
+  token: string
+  label: string
+  last_seen_at: string | null
+}
+
+type SettingsData = {
+  first_name: string | null
+  mcp_tokens: McpToken[]
+}
 
 export function SettingsPage() {
-  const { user } = useAuth()
+  const { user, refresh } = useAuth()
+  const [settings, setSettings] = useState<SettingsData | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  // Name editing
+  const [editingName, setEditingName] = useState(false)
+  const [nameValue, setNameValue] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [saveSuccess, setSaveSuccess] = useState(false)
+
+  // Token visibility
+  const [revealedTokens, setRevealedTokens] = useState<Set<string>>(new Set())
+  const [copiedToken, setCopiedToken] = useState<string | null>(null)
+
+  useEffect(() => {
+    fetchSettings()
+  }, [])
+
+  async function fetchSettings() {
+    try {
+      const data = await api<SettingsData>('/api/settings')
+      setSettings(data)
+      setNameValue(data.first_name ?? '')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load settings')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function saveName() {
+    if (!nameValue.trim()) return
+    setSaving(true)
+    setSaveSuccess(false)
+    try {
+      await api('/api/settings', {
+        method: 'PATCH',
+        body: JSON.stringify({ first_name: nameValue.trim() }),
+      })
+      setSettings((s) => s ? { ...s, first_name: nameValue.trim() } : s)
+      setEditingName(false)
+      setSaveSuccess(true)
+      refresh()
+      setTimeout(() => setSaveSuccess(false), 2000)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  function toggleToken(deviceId: string) {
+    setRevealedTokens((prev) => {
+      const next = new Set(prev)
+      if (next.has(deviceId)) next.delete(deviceId)
+      else next.add(deviceId)
+      return next
+    })
+  }
+
+  async function copyToken(token: string, deviceId: string) {
+    await navigator.clipboard.writeText(token)
+    setCopiedToken(deviceId)
+    setTimeout(() => setCopiedToken(null), 2000)
+  }
+
+  function maskToken(token: string) {
+    if (token.length <= 8) return '••••••••'
+    return token.slice(0, 4) + '••••••••' + token.slice(-4)
+  }
+
+  function formatDate(iso: string | null) {
+    if (!iso) return 'Never'
+    return new Date(iso + 'Z').toLocaleDateString(undefined, {
+      month: 'short', day: 'numeric', year: 'numeric',
+      hour: '2-digit', minute: '2-digit',
+    })
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <div className="animate-spin w-6 h-6 border-2 border-[var(--blue)] border-t-transparent rounded-full" />
+      </div>
+    )
+  }
+
+  if (error && !settings) {
+    return (
+      <div className="bg-red-500/10 border border-red-500/30 rounded-xl p-4 text-red-400">
+        {error}
+      </div>
+    )
+  }
 
   return (
-    <div>
+    <div className="max-w-2xl">
       <h1 className="text-2xl font-bold mb-6">Settings</h1>
 
-      <div className="bg-[var(--surface)] rounded-xl p-5 border border-[var(--surface-raised)]">
+      {error && (
+        <div className="bg-red-500/10 border border-red-500/30 rounded-xl p-3 text-red-400 text-sm mb-4">
+          {error}
+          <button onClick={() => setError(null)} className="ml-2 underline">Dismiss</button>
+        </div>
+      )}
+
+      {saveSuccess && (
+        <div className="bg-green-500/10 border border-green-500/30 rounded-xl p-3 text-green-400 text-sm mb-4">
+          Settings saved successfully.
+        </div>
+      )}
+
+      {/* Account Section */}
+      <section className="bg-[var(--surface)] rounded-xl p-5 border border-[var(--surface-raised)] mb-4">
         <h2 className="font-semibold mb-4">Account</h2>
         <div className="space-y-3 text-sm">
-          <div className="flex justify-between">
+          <div className="flex items-center justify-between">
             <span className="text-[var(--text-dim)]">Name</span>
-            <span>{user?.first_name || '—'}</span>
+            {editingName ? (
+              <div className="flex items-center gap-2">
+                <input
+                  type="text"
+                  value={nameValue}
+                  onChange={(e) => setNameValue(e.target.value)}
+                  maxLength={50}
+                  className="bg-[var(--bg)] border border-[var(--surface-raised)] rounded-lg px-3 py-1.5 text-sm w-48 focus:outline-none focus:border-[var(--blue)]"
+                  autoFocus
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') saveName()
+                    if (e.key === 'Escape') { setEditingName(false); setNameValue(settings?.first_name ?? '') }
+                  }}
+                />
+                <button
+                  onClick={saveName}
+                  disabled={saving || !nameValue.trim()}
+                  className="px-3 py-1.5 bg-[var(--blue)] text-white rounded-lg text-sm font-medium disabled:opacity-50"
+                >
+                  {saving ? 'Saving...' : 'Save'}
+                </button>
+                <button
+                  onClick={() => { setEditingName(false); setNameValue(settings?.first_name ?? '') }}
+                  className="px-3 py-1.5 text-[var(--text-dim)] hover:text-[var(--text)] text-sm"
+                >
+                  Cancel
+                </button>
+              </div>
+            ) : (
+              <div className="flex items-center gap-2">
+                <span>{settings?.first_name || '—'}</span>
+                <button
+                  onClick={() => setEditingName(true)}
+                  className="text-[var(--blue)] hover:underline text-xs"
+                >
+                  Edit
+                </button>
+              </div>
+            )}
           </div>
           <div className="flex justify-between">
             <span className="text-[var(--text-dim)]">Email</span>
             <span>{user?.email || '—'}</span>
           </div>
         </div>
-      </div>
+      </section>
 
-      <p className="text-xs text-[var(--text-muted)] mt-4">
-        Settings sync and device management coming in Phase 4.
-      </p>
+      {/* Linked Devices Section */}
+      <section className="bg-[var(--surface)] rounded-xl p-5 border border-[var(--surface-raised)]">
+        <h2 className="font-semibold mb-4">Linked Devices</h2>
+        {(!settings?.mcp_tokens || settings.mcp_tokens.length === 0) ? (
+          <p className="text-sm text-[var(--text-dim)]">
+            No devices linked to your account. Open the Robo app and sign in to link a device.
+          </p>
+        ) : (
+          <div className="space-y-3">
+            {settings.mcp_tokens.map((device) => (
+              <div
+                key={device.device_id}
+                className="bg-[var(--bg)] rounded-lg p-4 border border-[var(--surface-raised)]"
+              >
+                <div className="flex items-center justify-between mb-2">
+                  <span className="font-medium text-sm">{device.label}</span>
+                  <span className="text-xs text-[var(--text-muted)]">
+                    Last seen: {formatDate(device.last_seen_at)}
+                  </span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <code className="text-xs bg-[var(--surface)] px-2 py-1 rounded flex-1 font-mono overflow-hidden text-ellipsis">
+                    {revealedTokens.has(device.device_id)
+                      ? device.token
+                      : maskToken(device.token)}
+                  </code>
+                  <button
+                    onClick={() => toggleToken(device.device_id)}
+                    className="text-xs text-[var(--text-dim)] hover:text-[var(--text)] px-2 py-1"
+                  >
+                    {revealedTokens.has(device.device_id) ? 'Hide' : 'Reveal'}
+                  </button>
+                  <button
+                    onClick={() => copyToken(device.token, device.device_id)}
+                    className="text-xs text-[var(--blue)] hover:underline px-2 py-1"
+                  >
+                    {copiedToken === device.device_id ? 'Copied!' : 'Copy'}
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
     </div>
   )
 }

--- a/workers/src/index.ts
+++ b/workers/src/index.ts
@@ -18,6 +18,7 @@ import { serveOgImage } from './routes/ogImage';
 import { listAPIKeys, createAPIKey, deleteAPIKey } from './routes/apikeys';
 import { chatProxy } from './routes/chat';
 import { appleAuth, linkDevice, getMe, logout } from './routes/auth';
+import { getSettings, updateSettings } from './routes/settings';
 import { deviceAuth } from './middleware/deviceAuth';
 import { mcpTokenAuth } from './middleware/mcpTokenAuth';
 import { userAuth, csrfProtect } from './middleware/userAuth';
@@ -46,6 +47,10 @@ app.post('/api/auth/apple', csrfProtect, appleAuth);
 app.post('/api/auth/link-device', csrfProtect, userAuth, linkDevice);
 app.get('/api/auth/me', userAuth, getMe);
 app.post('/api/auth/logout', csrfProtect, logout);
+
+// Settings routes (user auth required)
+app.get('/api/settings', userAuth, getSettings);
+app.patch('/api/settings', csrfProtect, userAuth, updateSettings);
 
 // Device routes
 app.post('/api/devices/register', registerDevice);

--- a/workers/src/routes/settings.ts
+++ b/workers/src/routes/settings.ts
@@ -1,0 +1,60 @@
+import type { Context } from 'hono';
+import { UserSettingsSchema } from '@robo/shared';
+import type { Env } from '../types';
+
+/**
+ * GET /api/settings
+ * Returns user settings: first_name + linked devices with MCP tokens.
+ * Requires userAuth middleware.
+ */
+export async function getSettings(c: Context<{ Bindings: Env }>) {
+  const userId = c.get('userId');
+
+  const user = await c.env.DB.prepare(
+    'SELECT first_name FROM users WHERE id = ?'
+  ).bind(userId).first<{ first_name: string | null }>();
+
+  if (!user) {
+    return c.json({ error: 'User not found' }, 404);
+  }
+
+  const devices = await c.env.DB.prepare(
+    'SELECT id, name, mcp_token, last_seen_at FROM devices WHERE user_id = ?'
+  ).bind(userId).all<{ id: string; name: string; mcp_token: string; last_seen_at: string | null }>();
+
+  return c.json({
+    first_name: user.first_name,
+    mcp_tokens: (devices.results ?? []).map((d) => ({
+      device_id: d.id,
+      token: d.mcp_token,
+      label: d.name,
+      last_seen_at: d.last_seen_at,
+    })),
+  });
+}
+
+/**
+ * PATCH /api/settings
+ * Updates user settings (currently first_name).
+ * Validates with UserSettingsSchema from @robo/shared.
+ * Requires userAuth middleware.
+ */
+export async function updateSettings(c: Context<{ Bindings: Env }>) {
+  const userId = c.get('userId');
+
+  const body = await c.req.json().catch(() => null);
+  const parsed = UserSettingsSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: 'Invalid request', details: parsed.error.flatten() }, 400);
+  }
+
+  const { first_name } = parsed.data;
+
+  if (first_name !== undefined) {
+    await c.env.DB.prepare(
+      `UPDATE users SET first_name = ?, updated_at = datetime('now') WHERE id = ?`
+    ).bind(first_name, userId).run();
+  }
+
+  return c.json({ ok: true, first_name });
+}


### PR DESCRIPTION
## Summary
- **GET /api/settings** — returns `first_name` + linked devices with MCP tokens (userAuth required)
- **PATCH /api/settings** — updates `first_name` with `UserSettingsSchema` validation (userAuth + CSRF required)
- **Web Settings page** — editable first name, linked device list with masked MCP tokens, reveal/copy UX

Closes #225 (backend + web portions; iOS sync deferred to follow-on issue)

## Testing
- Workers dry-run build passes
- Web TypeScript type-check passes
- Manual: sign in on web → Settings → edit name → verify persistence

## Post-Deploy Monitoring & Validation
- **What to monitor**: `GET /api/settings` and `PATCH /api/settings` in Workers analytics
- **Expected healthy behavior**: 200 responses for authenticated users, 401 for unauthenticated
- **Failure signal**: 500 errors on settings endpoints → rollback worker deploy
- **Validation window**: 1 hour post-deploy

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)