### PR TITLE
fix: switch deploy-workers workflow from npm to pnpm

### DIFF
--- a/.github/workflows/deploy-workers.yml
+++ b/.github/workflows/deploy-workers.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-    paths: ['workers/**']
+    paths: ['workers/**', 'packages/**']
 
 concurrency:
   group: deploy-workers-${{ github.ref }}
@@ -19,20 +19,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: workers/package-lock.json
+          cache: 'pnpm'
 
       - name: Install dependencies
-        working-directory: workers
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Run tests
         working-directory: workers
-        run: npm test
+        run: pnpm test
 
       - name: Apply D1 migrations
         uses: cloudflare/wrangler-action@v3


### PR DESCRIPTION
## Summary
- Replaces `npm ci` with `pnpm install --frozen-lockfile` to support `workspace:*` protocol
- Adds `pnpm/action-setup@v4` (auto-detects version from `packageManager` field)
- Triggers deploy on `packages/**` changes (shared code)

Last 3 deploys all failed with `EUNSUPPORTEDPROTOCOL: workspace:*`.

## Test plan
- [ ] Merge and verify the workflow runs successfully
- [ ] Smoke tests pass against https://api.robo.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)